### PR TITLE
Feature: WithdrawOnlyPCVDeposit

### DIFF
--- a/contracts/pcv/WithdrawOnlyPCVDeposit.sol
+++ b/contracts/pcv/WithdrawOnlyPCVDeposit.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import {IERC20, PCVDeposit, CoreRef} from "./PCVDeposit.sol";
+
+/// @title ERC20 token deposit contract that allows for withdrawing
+/// of ERC-20 tokens using a PCV Controller
+/// Meant to slot into the current Volt system to allow users to redeem
+/// volt for FEI through the Non Custodial PSM
+/// @author Elliot Friedman
+contract WithdrawOnlyPCVDeposit is PCVDeposit {
+    /// @notice the token underlying the cToken
+    IERC20 public immutable token;
+
+    constructor(address _core, IERC20 _token) CoreRef(_core) {
+        token = _token;
+    }
+
+    /// @notice reverts to ensure deposit cannot be called
+    function deposit() external override {
+        revert("WithdrawOnlyPCVDeposit: deposit not allowed");
+    }
+
+    /// @notice withdraw ERC20 from the contract
+    /// @param to address destination of the ERC20
+    /// @param amount quantity of ERC20 to send
+    function withdraw(address to, uint256 amount)
+        public
+        override
+        onlyPCVController
+    {
+        _withdrawERC20(address(token), to, amount);
+    }
+
+    /// @notice return the balance of the underlying token in this PCV Deposit
+    function balance() public view override returns (uint256) {
+        return token.balanceOf(address(this));
+    }
+
+    /// @notice display the related token of the balance reported
+    function balanceReportedIn() public view override returns (address) {
+        return address(token);
+    }
+}

--- a/contracts/test/unit/pcv/WithdrawOnlyPCVDeposit.t.sol
+++ b/contracts/test/unit/pcv/WithdrawOnlyPCVDeposit.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {IVolt} from "../../../volt/Volt.sol";
+import {Volt} from "../../../volt/Volt.sol";
+import {ICore} from "../../../core/ICore.sol";
+import {Core} from "../../../core/Core.sol";
+import {Vm} from "./../utils/Vm.sol";
+import {DSTest} from "./../utils/DSTest.sol";
+import {getCore, getAddresses, FeiTestAddresses} from "./../utils/Fixtures.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {WithdrawOnlyPCVDeposit} from "./../../../pcv/WithdrawOnlyPCVDeposit.sol";
+import {MockERC20} from "./../../../mock/MockERC20.sol";
+
+contract WithdrawOnlyPCVDepositTest is DSTest {
+    MockERC20 public token;
+
+    IVolt private volt;
+    Core private core;
+    WithdrawOnlyPCVDeposit private deposit;
+
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+    FeiTestAddresses public addresses = getAddresses();
+
+    function setUp() public {
+        token = new MockERC20();
+        core = getCore();
+
+        volt = core.volt();
+        deposit = new WithdrawOnlyPCVDeposit(
+            address(core),
+            IERC20(address(token))
+        );
+    }
+
+    function testTokenIsSet() public {
+        assertEq(address(deposit.token()), address(token));
+    }
+
+    function testBalance() public {
+        uint256 tokenAmount = 100;
+        token.mint(address(deposit), tokenAmount);
+        assertEq(deposit.balance(), tokenAmount);
+    }
+
+    function testBalanceReportedIn() public {
+        assertEq(deposit.balanceReportedIn(), address(token));
+    }
+
+    function testWithdrawAsPCVController() public {
+        uint256 tokenAmount = 100;
+        token.mint(address(deposit), tokenAmount);
+
+        vm.prank(addresses.pcvControllerAddress);
+        deposit.withdraw(address(this), tokenAmount);
+
+        assertEq(token.balanceOf(address(this)), tokenAmount);
+    }
+
+    function testWithdrawERC20AsPCVController() public {
+        MockERC20 newToken = new MockERC20();
+
+        uint256 tokenAmount = 100;
+        newToken.mint(address(deposit), tokenAmount);
+
+        vm.prank(addresses.pcvControllerAddress);
+        deposit.withdrawERC20(address(newToken), address(this), tokenAmount);
+
+        assertEq(newToken.balanceOf(address(this)), tokenAmount);
+    }
+
+    function testWithdrawFailsAsNonPCVController() public {
+        vm.expectRevert("CoreRef: Caller is not a PCV controller");
+        deposit.withdraw(address(this), 1);
+    }
+
+    function testDepositFails() public {
+        vm.expectRevert("WithdrawOnlyPCVDeposit: deposit not allowed");
+        deposit.deposit();
+    }
+}


### PR DESCRIPTION
This is a PR to create a new type of PCV Deposit to enable the NonCustodial PSM to hook into this new deposit, and allow redemptions of Volt for Fei.

TODO:
- Integration Test
- Deployment Script