### PR TITLE
Aave PCV Deposit

### DIFF
--- a/contracts/mock/MockLendingPool.sol
+++ b/contracts/mock/MockLendingPool.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import "./MockERC20.sol";
+
+/// @title Aave PCV Deposit
+/// @author Fei Protocol
+contract MockLendingPool {
+    MockERC20 public aToken;
+
+    constructor() {
+        aToken = new MockERC20();
+    }
+
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16 /// shhhh
+    ) external {
+        IERC20(asset).transferFrom(msg.sender, address(this), amount);
+        aToken.mint(onBehalfOf, amount);
+    }
+
+    function withdraw(
+        address asset,
+        uint256 amount,
+        address to
+    ) external {
+        aToken.approveOverride(msg.sender, address(this), amount);
+        aToken.burnFrom(msg.sender, amount);
+
+        IERC20(asset).transfer(to, amount);
+    }
+}

--- a/contracts/pcv/aave/ERC20AavePCVDeposit.sol
+++ b/contracts/pcv/aave/ERC20AavePCVDeposit.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import {PCVDeposit, IERC20, CoreRef} from "./../PCVDeposit.sol";
+import {IAavePCVDeposit, LendingPool, IncentivesController} from "./IAavePCVDeposit.sol";
+
+/// @title ERC20 Aave PCV Deposit
+/// @author Fei Protocol
+contract ERC20AavePCVDeposit is IAavePCVDeposit, PCVDeposit {
+    /// @notice the associated Aave aToken for the deposit
+    IERC20 public immutable override aToken;
+
+    /// @notice the Aave v2 lending pool
+    LendingPool public immutable override lendingPool;
+
+    /// @notice the underlying token of the PCV deposit
+    IERC20 public immutable token;
+
+    /// @notice the Aave incentives controller for the aToken
+    IncentivesController public immutable override incentivesController;
+
+    /// @notice Aave PCV Deposit constructor
+    /// @param _core Fei Core for reference
+    /// @param _lendingPool the Aave v2 lending pool
+    /// @param _token the underlying token of the PCV deposit
+    /// @param _aToken the associated Aave aToken for the deposit
+    /// @param _incentivesController the Aave incentives controller for the aToken
+    constructor(
+        address _core,
+        LendingPool _lendingPool,
+        IERC20 _token,
+        IERC20 _aToken,
+        IncentivesController _incentivesController
+    ) CoreRef(_core) {
+        lendingPool = _lendingPool;
+        aToken = _aToken;
+        token = _token;
+        incentivesController = _incentivesController;
+    }
+
+    /// @notice claims Aave rewards from the deposit and transfers to this address
+    function claimRewards() external {
+        address[] memory assets = new address[](1);
+        assets[0] = address(aToken);
+        // First grab the available balance
+        uint256 amount = incentivesController.getRewardsBalance(
+            assets,
+            address(this)
+        );
+
+        // claim all available rewards
+        incentivesController.claimRewards(assets, amount, address(this));
+
+        emit ClaimRewards(msg.sender, amount);
+    }
+
+    /// @notice deposit buffered aTokens
+    function deposit() external override whenNotPaused {
+        // Approve and deposit buffered tokens
+        uint256 pendingBalance = token.balanceOf(address(this));
+        token.approve(address(lendingPool), pendingBalance);
+        lendingPool.deposit(address(token), pendingBalance, address(this), 0);
+
+        emit Deposit(msg.sender, pendingBalance);
+    }
+
+    /// @notice withdraw tokens from the PCV allocation
+    /// @param amountUnderlying of tokens withdrawn
+    /// @param to the address to send PCV to
+    function withdraw(address to, uint256 amountUnderlying)
+        external
+        override
+        onlyPCVController
+    {
+        lendingPool.withdraw(address(token), amountUnderlying, to);
+        emit Withdrawal(msg.sender, to, amountUnderlying);
+    }
+
+    /// @notice returns total balance of PCV in the Deposit
+    /// @dev aTokens are rebasing, so represent 1:1 on underlying value
+    function balance() public view override returns (uint256) {
+        return aToken.balanceOf(address(this));
+    }
+
+    /// @notice display the related token of the balance reported
+    function balanceReportedIn() public view override returns (address) {
+        return address(token);
+    }
+}

--- a/contracts/pcv/aave/IAavePCVDeposit.sol
+++ b/contracts/pcv/aave/IAavePCVDeposit.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+import {IERC20, CoreRef} from "./../PCVDeposit.sol";
+
+interface LendingPool {
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16 referralCode
+    ) external;
+
+    function withdraw(
+        address asset,
+        uint256 amount,
+        address to
+    ) external;
+}
+
+interface IncentivesController {
+    function claimRewards(
+        address[] calldata assets,
+        uint256 amount,
+        address to
+    ) external;
+
+    function getRewardsBalance(address[] calldata assets, address user)
+        external
+        view
+        returns (uint256);
+}
+
+/// @title Aave PCV Deposit
+/// @author Volt Protocol
+interface IAavePCVDeposit {
+    /// @notice event emitted when rewards are claimed
+    event ClaimRewards(address indexed caller, uint256 amount);
+
+    /// @notice the associated Aave aToken for the deposit
+    function aToken() external view returns (IERC20);
+
+    /// @notice the Aave v2 lending pool
+    function lendingPool() external view returns (LendingPool);
+
+    /// @notice the underlying token of the PCV deposit
+    function token() external view returns (IERC20);
+
+    /// @notice the Aave incentives controller for the aToken
+    function incentivesController()
+        external
+        view
+        returns (IncentivesController);
+
+    /// @notice claims Aave rewards from the deposit and transfers to this address
+    function claimRewards() external;
+}

--- a/contracts/test/unit/pcv/aave/ERC20AavePCVDeposit.t.sol
+++ b/contracts/test/unit/pcv/aave/ERC20AavePCVDeposit.t.sol
@@ -19,8 +19,10 @@ contract ERC20AavePCVDepositTest is DSTest {
     MockLendingPool private lendingPool;
     ERC20AavePCVDeposit private aaveDeposit;
     ICore private core;
+    FeiTestAddresses public addresses = getAddresses();
+    Vm public constant vm = Vm(HEVM_ADDRESS);
 
-    function setup() public {
+    function setUp() public {
         core = getCore();
         lendingPool = new MockLendingPool();
         aToken = lendingPool.aToken();
@@ -35,6 +37,18 @@ contract ERC20AavePCVDepositTest is DSTest {
     }
 
     /// only pcv controller successfully withdraws
+    function testPCVControllerWithdraws() public {
+        uint256 amount = 1000;
+        token.mint(address(aaveDeposit), amount);
+        aaveDeposit.deposit();
+
+        vm.prank(addresses.pcvControllerAddress);
+        aaveDeposit.withdraw(address(this), amount);
+    }
+
     /// non pcv controller cannot withdraw
-    /// anyone can claim
+    function testNonPCVControllerCannotWithdraw() public {
+        vm.expectRevert(bytes("CoreRef: Caller is not a PCV controller"));
+        aaveDeposit.withdraw(address(this), 1000);
+    }
 }

--- a/contracts/test/unit/pcv/aave/ERC20AavePCVDeposit.t.sol
+++ b/contracts/test/unit/pcv/aave/ERC20AavePCVDeposit.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.4;
+
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {ERC20, IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {Vm} from "./../../utils/Vm.sol";
+import {ICore} from "../../../../core/ICore.sol";
+import {DSTest} from "./../../utils/DSTest.sol";
+import {MockERC20, MockLendingPool} from "../../../../mock/MockLendingPool.sol";
+import {ERC20AavePCVDeposit, LendingPool, IncentivesController} from "../../../../pcv/aave/ERC20AavePCVDeposit.sol";
+import {getCore, getAddresses, FeiTestAddresses} from "./../../utils/Fixtures.sol";
+
+contract ERC20AavePCVDepositTest is DSTest {
+    using SafeCast for *;
+
+    IERC20 private aToken;
+    MockERC20 private token;
+    MockLendingPool private lendingPool;
+    ERC20AavePCVDeposit private aaveDeposit;
+    ICore private core;
+
+    function setup() public {
+        core = getCore();
+        lendingPool = new MockLendingPool();
+        aToken = lendingPool.aToken();
+        token = new MockERC20();
+        aaveDeposit = new ERC20AavePCVDeposit(
+            address(core),
+            LendingPool(address(lendingPool)),
+            IERC20(address(token)),
+            IERC20(address(aToken)),
+            IncentivesController(address(0)) /// incentives controller is not tested in unit tests
+        );
+    }
+
+    /// only pcv controller successfully withdraws
+    /// non pcv controller cannot withdraw
+    /// anyone can claim
+}

--- a/test/unit/pcv/aave/ERC20AavePCVDeposit.test.ts
+++ b/test/unit/pcv/aave/ERC20AavePCVDeposit.test.ts
@@ -1,0 +1,140 @@
+import { expectRevert, getAddresses, getCore } from '@test/helpers';
+import { expect } from 'chai';
+import hre, { ethers } from 'hardhat';
+import { Signer } from 'ethers';
+
+const toBN = ethers.BigNumber.from;
+
+describe('AavePCVDeposit', function () {
+  let userAddress: string;
+  let pcvControllerAddress: string;
+  let governorAddress: string;
+
+  const impersonatedSigners: { [key: string]: Signer } = {};
+
+  before(async () => {
+    const addresses = await getAddresses();
+
+    const impersonatedAddresses = [addresses.userAddress, addresses.pcvControllerAddress, addresses.governorAddress];
+
+    for (const address of impersonatedAddresses) {
+      await hre.network.provider.request({
+        method: 'hardhat_impersonateAccount',
+        params: [address]
+      });
+
+      impersonatedSigners[address] = await ethers.getSigner(address);
+    }
+  });
+
+  beforeEach(async function () {
+    ({ userAddress, pcvControllerAddress, governorAddress } = await getAddresses());
+
+    this.core = await getCore();
+
+    const lendingPoolFactory = await ethers.getContractFactory('MockLendingPool');
+    this.lendingPool = await lendingPoolFactory.deploy();
+
+    const tokenFactory = await ethers.getContractFactory('MockERC20');
+    this.token = await tokenFactory.deploy();
+    this.aToken = await ethers.getContractAt('MockERC20', await this.lendingPool.aToken());
+
+    const aavePCVDepositFactory = await ethers.getContractFactory('ERC20AavePCVDeposit');
+    this.aavePCVDeposit = await aavePCVDepositFactory.deploy(
+      this.core.address,
+      this.lendingPool.address,
+      this.token.address,
+      this.aToken.address,
+      this.token.address // filling in dummy address for incentives controller
+    );
+
+    this.depositAmount = toBN('1000000000000000000');
+  });
+
+  describe('Deposit', function () {
+    describe('Paused', function () {
+      it('reverts', async function () {
+        await this.aavePCVDeposit.connect(impersonatedSigners[governorAddress]).pause();
+        await expectRevert(this.aavePCVDeposit.deposit(), 'Pausable: paused');
+      });
+    });
+
+    describe('Not Paused', function () {
+      beforeEach(async function () {
+        await this.token.mint(this.aavePCVDeposit.address, this.depositAmount);
+      });
+
+      it('succeeds', async function () {
+        expect(await this.aavePCVDeposit.balance()).to.be.equal(toBN('0'));
+        await this.aavePCVDeposit.deposit();
+        // Balance should increment with the new deposited aTokens underlying
+        expect(await this.aavePCVDeposit.balance()).to.be.equal(this.depositAmount);
+
+        // Held balance should be 0, now invested into Aave
+        expect(await this.token.balanceOf(this.aavePCVDeposit.address)).to.be.equal(toBN('0'));
+      });
+    });
+  });
+
+  describe('Withdraw', function () {
+    beforeEach(async function () {
+      await this.token.mint(this.aavePCVDeposit.address, this.depositAmount);
+      await this.aavePCVDeposit.deposit();
+    });
+
+    describe('Not PCVController', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.aavePCVDeposit.connect(impersonatedSigners[userAddress]).withdraw(userAddress, this.depositAmount),
+          'CoreRef: Caller is not a PCV controller'
+        );
+      });
+    });
+
+    it('succeeds', async function () {
+      const userBalanceBefore = await this.token.balanceOf(userAddress);
+
+      // withdrawing should take balance back to 0
+      expect(await this.aavePCVDeposit.balance()).to.be.equal(this.depositAmount);
+      await this.aavePCVDeposit
+        .connect(impersonatedSigners[pcvControllerAddress])
+        .withdraw(userAddress, this.depositAmount);
+      expect(await this.aavePCVDeposit.balance()).to.be.equal(toBN('0'));
+
+      const userBalanceAfter = await this.token.balanceOf(userAddress);
+
+      expect(userBalanceAfter.sub(userBalanceBefore)).to.be.equal(this.depositAmount);
+    });
+  });
+
+  describe('WithdrawERC20', function () {
+    describe('Not PCVController', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.aavePCVDeposit
+            .connect(impersonatedSigners[userAddress])
+            .withdrawERC20(this.aToken.address, userAddress, this.depositAmount),
+          'CoreRef: Caller is not a PCV controller'
+        );
+      });
+    });
+
+    describe('From PCVController', function () {
+      beforeEach(async function () {
+        await this.token.mint(this.aavePCVDeposit.address, this.depositAmount);
+        await this.aavePCVDeposit.deposit();
+      });
+
+      it('succeeds', async function () {
+        expect(await this.aavePCVDeposit.balance()).to.be.equal(this.depositAmount);
+        await this.aavePCVDeposit
+          .connect(impersonatedSigners[pcvControllerAddress])
+          .withdrawERC20(this.aToken.address, userAddress, this.depositAmount.div(toBN('2')));
+
+        // balance should also get cut in half
+        expect(await this.aavePCVDeposit.balance()).to.be.equal(this.depositAmount.div(toBN('2')));
+        expect(await this.aToken.balanceOf(userAddress)).to.be.equal(this.depositAmount.div(toBN('2')));
+      });
+    });
+  });
+});


### PR DESCRIPTION
PCV Deposit contract that deposits assets into AAVE. There were a few small changes made to this code compared to the Fei implementation such as:
- not automatically wrapping or unwrapping eth
- making all state variables in the ERC20AavePCVDeposit immutable as governance cannot change them
- Directly inheriting PCVDeposit instead of inheriting WethPCVDeposit

diff: https://www.diffchecker.com/A4VTPULP