### PR TITLE
Clean up Compound PCV Deposit imports, Make token and cToken immutable

### DIFF
--- a/contracts/pcv/compound/CErc20.sol
+++ b/contracts/pcv/compound/CErc20.sol
@@ -1,0 +1,7 @@
+pragma solidity =0.8.13;
+
+interface CErc20 {
+    function mint(uint256 amount) external returns (uint256);
+
+    function underlying() external returns (address);
+}

--- a/contracts/pcv/compound/CToken.sol
+++ b/contracts/pcv/compound/CToken.sol
@@ -1,0 +1,13 @@
+pragma solidity =0.8.13;
+
+interface CToken {
+    function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
+
+    function exchangeRateStored() external view returns (uint256);
+
+    function balanceOf(address account) external view returns (uint256);
+
+    function isCToken() external view returns (bool);
+
+    function isCEther() external view returns (bool);
+}

--- a/contracts/pcv/compound/CompoundPCVDepositBase.sol
+++ b/contracts/pcv/compound/CompoundPCVDepositBase.sol
@@ -1,31 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
+pragma solidity =0.8.13;
 
-import "../PCVDeposit.sol";
-import "../../refs/CoreRef.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-
-interface CToken {
-    function redeemUnderlying(uint256 redeemAmount) external returns (uint256);
-
-    function exchangeRateStored() external view returns (uint256);
-
-    function balanceOf(address account) external view returns (uint256);
-
-    function isCToken() external view returns (bool);
-
-    function isCEther() external view returns (bool);
-}
+import {PCVDeposit} from "../PCVDeposit.sol";
+import {CoreRef} from "../../refs/CoreRef.sol";
+import {CToken} from "./CToken.sol";
 
 /// @title base class for a Compound PCV Deposit
 /// @author Fei Protocol
 abstract contract CompoundPCVDepositBase is PCVDeposit {
-    CToken public cToken;
+    CToken public immutable cToken;
 
     uint256 private constant EXCHANGE_RATE_SCALE = 1e18;
 
     /// @notice Compound PCV Deposit constructor
-    /// @param _core Fei Core for reference
+    /// @param _core Volt Core for reference
     /// @param _cToken Compound cToken to deposit
     constructor(address _core, address _cToken) CoreRef(_core) {
         cToken = CToken(_cToken);
@@ -49,7 +37,7 @@ abstract contract CompoundPCVDepositBase is PCVDeposit {
         emit Withdrawal(msg.sender, to, amountUnderlying);
     }
 
-    /// @notice returns total balance of PCV in the Deposit excluding the FEI
+    /// @notice returns total balance of PCV in the Deposit excluding the VOLT
     /// @dev returns stale values from Compound if the market hasn't been updated
     function balance() public view override returns (uint256) {
         uint256 exchangeRate = cToken.exchangeRateStored();

--- a/contracts/pcv/compound/ERC20CompoundPCVDeposit.sol
+++ b/contracts/pcv/compound/ERC20CompoundPCVDeposit.sol
@@ -1,22 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "./CompoundPCVDepositBase.sol";
-
-interface CErc20 {
-    function mint(uint256 amount) external returns (uint256);
-
-    function underlying() external returns (address);
-}
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {CompoundPCVDepositBase} from "./CompoundPCVDepositBase.sol";
+import {CErc20} from "./CErc20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /// @title ERC-20 implementation for a Compound PCV Deposit
 /// @author Fei Protocol
 contract ERC20CompoundPCVDeposit is CompoundPCVDepositBase {
     /// @notice the token underlying the cToken
-    IERC20 public token;
+    IERC20 public immutable token;
 
     /// @notice Compound ERC20 PCV Deposit constructor
-    /// @param _core Fei Core for reference
+    /// @param _core Volt Core for reference
     /// @param _cToken Compound cToken to deposit
     constructor(address _core, address _cToken)
         CompoundPCVDepositBase(_core, _cToken)


### PR DESCRIPTION
Make token and ctoken immutable in compound PCV deposit as there is no method to change them
Clean up imports
Move inlined interfaces into a separate file