### PR TITLE
Compound PCV Router

### DIFF
--- a/contracts/pcv/compound/CToken.sol
+++ b/contracts/pcv/compound/CToken.sol
@@ -10,4 +10,6 @@ interface CToken {
     function isCToken() external view returns (bool);
 
     function isCEther() external view returns (bool);
+
+    function accrueInterest() external returns (uint256);
 }

--- a/contracts/pcv/compound/CompoundPCVRouter.sol
+++ b/contracts/pcv/compound/CompoundPCVRouter.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity =0.8.13;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {IDSSPSM} from "./../maker/IDSSPSM.sol";
+import {CoreRef} from "../../refs/CoreRef.sol";
+import {Constants} from "../../Constants.sol";
+import {TribeRoles} from "../../core/TribeRoles.sol";
+import {PCVDeposit} from "../PCVDeposit.sol";
+import {IPegStabilityModule} from "../../peg/IPegStabilityModule.sol";
+
+/// @notice This contracts allows for swaps between DAI and USDC
+/// by using the Maker DAI-USDC PSM
+/// @author Elliot Friedman, Kassim
+contract CompoundPCVRouter is CoreRef {
+    using SafeERC20 for IERC20;
+
+    /// @notice reference to the Maker DAI-USDC PSM that this router interacts with
+    /// @dev points to Makers DssPsm contract
+    IDSSPSM public immutable daiPSM;
+
+    /// @notice reference to the Compound PCV deposit for USDC
+    PCVDeposit public immutable daiPcvDeposit;
+
+    /// @notice reference to the Compound PCV deposit for DAI
+    PCVDeposit public immutable usdcPcvDeposit;
+
+    /// @notice reference to the DAI contract used.
+    /// @dev Router can be redeployed if DAI address changes
+    IERC20 public constant DAI =
+        IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+
+    /// @notice reference to the USDC contract used.
+    IERC20 public constant USDC =
+        IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+
+    /// @notice reference to the contract used to sell USDC for DAI
+    address public constant GEM_JOIN =
+        0x0A59649758aa4d66E25f08Dd01271e891fe52199;
+
+    /// @notice scaling factor for USDC
+    uint256 public constant USDC_SCALING_FACTOR = 1e12;
+
+    /// @param _core reference to the core contract
+    /// @param _daiPSM Maker DAO DAI PSM
+    /// @param _daiPcvDeposit DAI PCV Deposit in compound
+    /// @param _usdcPcvDeposit USDC PCV Deposit in compound
+    constructor(
+        address _core,
+        address _daiPSM,
+        PCVDeposit _daiPcvDeposit,
+        PCVDeposit _usdcPcvDeposit
+    ) CoreRef(_core) {
+        daiPSM = IDSSPSM(_daiPSM);
+        daiPcvDeposit = _daiPcvDeposit;
+        usdcPcvDeposit = _usdcPcvDeposit;
+    }
+
+    /// @notice Function to swap cUSDC for cDAI
+    /// @param amountUsdcIn the amount of USDC sold to the DAI PSM
+    function swapUsdcForDai(uint256 amountUsdcIn)
+        external
+        hasAnyOfThreeRoles(
+            TribeRoles.GOVERNOR,
+            TribeRoles.PCV_CONTROLLER,
+            TribeRoles.PCV_GUARD
+        )
+    {
+        usdcPcvDeposit.withdraw(address(this), amountUsdcIn); /// pull USDC to router
+        USDC.safeApprove(GEM_JOIN, amountUsdcIn); /// approve DAI PSM to spend USDC
+        daiPSM.sellGem(address(daiPcvDeposit), amountUsdcIn); /// sell USDC for DAI
+        daiPcvDeposit.deposit(); /// deposit into compound
+    }
+
+    /// @notice Function to swap cDAI for cUSDC
+    /// @param amountDaiIn the amount of DAI sold to the DAI PSM in exchange for USDC
+    function swapDaiForUsdc(uint256 amountDaiIn)
+        external
+        hasAnyOfThreeRoles(
+            TribeRoles.GOVERNOR,
+            TribeRoles.PCV_CONTROLLER,
+            TribeRoles.PCV_GUARD
+        )
+    {
+        daiPcvDeposit.withdraw(address(this), amountDaiIn); /// pull DAI to router
+        DAI.safeApprove(address(daiPSM), amountDaiIn); /// approve DAI PSM to spend DAI
+        daiPSM.buyGem(
+            address(usdcPcvDeposit),
+            amountDaiIn / USDC_SCALING_FACTOR
+        ); /// sell DAI for USDC
+        usdcPcvDeposit.deposit(); /// deposit into compound
+    }
+}

--- a/contracts/pcv/compound/CompoundPCVRouter.sol
+++ b/contracts/pcv/compound/CompoundPCVRouter.sol
@@ -18,16 +18,16 @@ import {IPegStabilityModule} from "../../peg/IPegStabilityModule.sol";
 contract CompoundPCVRouter is CoreRef {
     using SafeERC20 for IERC20;
 
-    /// @notice reference to the Maker DAI-USDC PSM that this router interacts with
-    /// @dev points to Makers DssPsm contract
-    IDSSPSM public immutable daiPSM =
-        IDSSPSM(0x89B78CfA322F6C5dE0aBcEecab66Aee45393cC5A);
-
     /// @notice reference to the Compound PCV deposit for USDC
     PCVDeposit public immutable daiPcvDeposit;
 
     /// @notice reference to the Compound PCV deposit for DAI
     PCVDeposit public immutable usdcPcvDeposit;
+
+    /// @notice reference to the Maker DAI-USDC PSM that this router interacts with
+    /// @dev points to Makers DssPsm contract
+    IDSSPSM public constant daiPSM =
+        IDSSPSM(0x89B78CfA322F6C5dE0aBcEecab66Aee45393cC5A);
 
     /// @notice reference to the DAI contract used.
     /// @dev Router can be redeployed if DAI address changes

--- a/contracts/pcv/maker/IDSSPSM.sol
+++ b/contracts/pcv/maker/IDSSPSM.sol
@@ -9,4 +9,10 @@ interface IDSSPSM {
 
     /// @notice Swap collateral type for DAI
     function sellGem(address usr, uint256 gemAmt) external;
+
+    /// @notice redeem fee
+    function tin() external view returns (uint256);
+
+    /// @notice mint fee
+    function tout() external view returns (uint256);
 }

--- a/contracts/pcv/maker/IDSSPSM.sol
+++ b/contracts/pcv/maker/IDSSPSM.sol
@@ -15,4 +15,7 @@ interface IDSSPSM {
 
     /// @notice mint fee
     function tout() external view returns (uint256);
+
+    /// @notice set mint or redeem fee
+    function file(bytes32 what, uint256 data) external;
 }

--- a/contracts/test/integration/compound/IntegrationTestCompoundPCVRouter.t.sol
+++ b/contracts/test/integration/compound/IntegrationTestCompoundPCVRouter.t.sol
@@ -41,7 +41,6 @@ contract CompoundPCVRouterIntegrationTest is DSTest {
     function setUp() public {
         compoundRouter = new CompoundPCVRouter(
             address(core),
-            MainnetAddresses.MAKER_DAI_USDC_PSM,
             daiDeposit,
             usdcDeposit
         );
@@ -77,7 +76,7 @@ contract CompoundPCVRouterIntegrationTest is DSTest {
                 .toInt256(),
             0
         );
-        assertTrue(daiDeposit.balance() < 1e18); /// assert only dust remains
+        assertTrue(daiDeposit.balance() < 10e18); /// assert only dust remains
     }
 
     function testSwapUsdcToDaiSucceeds() public {
@@ -125,7 +124,7 @@ contract CompoundPCVRouterIntegrationTest is DSTest {
                 .toInt256(),
             0
         );
-        assertTrue(daiDeposit.balance() < 1e18); /// assert only dust remains
+        assertTrue(daiDeposit.balance() < 10e18); /// assert only dust remains
     }
 
     function testSwapUsdcToDaiFailsNoLiquidity() public {

--- a/contracts/test/integration/compound/IntegrationTestCompoundPCVRouter.t.sol
+++ b/contracts/test/integration/compound/IntegrationTestCompoundPCVRouter.t.sol
@@ -4,14 +4,16 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 import {Vm} from "../../unit/utils/Vm.sol";
-import {DSTest} from "../../unit/utils/DSTest.sol";
-import {CompoundPCVRouter} from "../../../pcv/compound/CompoundPCVRouter.sol";
-import {ERC20CompoundPCVDeposit} from "../../../pcv/compound/ERC20CompoundPCVDeposit.sol";
 import {Core} from "../../../core/Core.sol";
-import {TribeRoles} from "../../../core/TribeRoles.sol";
+import {stdError} from "../../unit/utils/StdLib.sol";
+import {DSTest} from "../../unit/utils/DSTest.sol";
 import {MockERC20} from "../../../mock/MockERC20.sol";
+import {TribeRoles} from "../../../core/TribeRoles.sol";
+import {PCVGuardian} from "../../../pcv/PCVGuardian.sol";
 import {MainnetAddresses} from "../fixtures/MainnetAddresses.sol";
 import {ArbitrumAddresses} from "../fixtures/ArbitrumAddresses.sol";
+import {CompoundPCVRouter} from "../../../pcv/compound/CompoundPCVRouter.sol";
+import {ERC20CompoundPCVDeposit} from "../../../pcv/compound/ERC20CompoundPCVDeposit.sol";
 
 contract CompoundPCVRouterIntegrationTest is DSTest {
     using SafeCast for *;
@@ -24,26 +26,19 @@ contract CompoundPCVRouterIntegrationTest is DSTest {
     address private governor = MainnetAddresses.GOVERNOR;
 
     CompoundPCVRouter private compoundRouter;
-    ERC20CompoundPCVDeposit private daiDeposit;
-    ERC20CompoundPCVDeposit private usdcDeposit;
+    ERC20CompoundPCVDeposit private daiDeposit =
+        ERC20CompoundPCVDeposit(MainnetAddresses.COMPOUND_DAI_PCV_DEPOSIT);
+    ERC20CompoundPCVDeposit private usdcDeposit =
+        ERC20CompoundPCVDeposit(MainnetAddresses.COMPOUND_USDC_PCV_DEPOSIT);
 
-    uint256 public constant depositAmount = 10_000_000e18;
-    address public constant compoundPCVMover = address(1);
+    address public immutable pcvGuard = MainnetAddresses.EOA_1;
+    PCVGuardian public immutable pcvGuardian =
+        PCVGuardian(MainnetAddresses.PCV_GUARDIAN);
 
     /// @notice scaling factor for USDC
     uint256 public constant USDC_SCALING_FACTOR = 1e12;
 
     function setUp() public {
-        daiDeposit = new ERC20CompoundPCVDeposit(
-            address(core),
-            MainnetAddresses.CDAI
-        );
-
-        usdcDeposit = new ERC20CompoundPCVDeposit(
-            address(core),
-            MainnetAddresses.CUSDC
-        );
-
         compoundRouter = new CompoundPCVRouter(
             address(core),
             MainnetAddresses.MAKER_DAI_USDC_PSM,
@@ -51,37 +46,11 @@ contract CompoundPCVRouterIntegrationTest is DSTest {
             usdcDeposit
         );
 
-        /// role setup
         vm.prank(governor);
         core.grantPCVController(address(compoundRouter));
-
-        /// get funding for PCV Deposits
-        vm.startPrank(MainnetAddresses.DAI_USDC_USDT_CURVE_POOL);
-        dai.transfer(address(daiDeposit), depositAmount);
-        usdc.transfer(
-            address(usdcDeposit),
-            depositAmount / USDC_SCALING_FACTOR
-        );
-        vm.stopPrank();
-
-        daiDeposit.deposit();
-        usdcDeposit.deposit();
     }
 
     function testSetup() public {
-        /// cToken share price rounds down against depositors,
-        /// this means balance is a hair under deposit amount
-        assertApproxEq(
-            daiDeposit.balance().toInt256(),
-            depositAmount.toInt256(),
-            0
-        );
-        assertApproxEq(
-            usdcDeposit.balance().toInt256(),
-            (depositAmount / USDC_SCALING_FACTOR).toInt256(),
-            0
-        );
-
         assertTrue(core.isPCVController(address(compoundRouter)));
 
         assertEq(
@@ -97,45 +66,95 @@ contract CompoundPCVRouterIntegrationTest is DSTest {
 
     function testSwapDaiToUsdcSucceeds() public {
         uint256 withdrawAmount = daiDeposit.balance();
+        uint256 usdcStartingBalance = usdcDeposit.balance();
 
         vm.prank(governor);
         compoundRouter.swapDaiForUsdc(withdrawAmount); /// withdraw all balance
 
         assertApproxEq(
             usdcDeposit.balance().toInt256(),
-            ((withdrawAmount * 2) / USDC_SCALING_FACTOR).toInt256(),
+            (withdrawAmount / USDC_SCALING_FACTOR + usdcStartingBalance)
+                .toInt256(),
             0
         );
-        assertTrue(daiDeposit.balance() < 1e9); /// assert only dust remains
+        assertTrue(daiDeposit.balance() < 1e18); /// assert only dust remains
     }
 
     function testSwapUsdcToDaiSucceeds() public {
         uint256 withdrawAmount = usdcDeposit.balance();
+        uint256 daiStartingBalance = daiDeposit.balance();
 
         vm.prank(governor);
         compoundRouter.swapUsdcForDai(withdrawAmount); /// withdraw all balance
 
         assertApproxEq(
             daiDeposit.balance().toInt256(),
-            (depositAmount * 2).toInt256(),
+            (withdrawAmount * USDC_SCALING_FACTOR + daiStartingBalance)
+                .toInt256(),
             0
         );
-        assertTrue(usdcDeposit.balance() < 1e3); /// assert only dust remains
+        assertTrue(usdcDeposit.balance() < 1e6); /// assert only dust remains
     }
 
-    function testSwapUsdcToDaiSucceedsCompPCVMover() public {
-        vm.prank(compoundPCVMover);
+    function testSwapUsdcToDaiSucceedsPCVGuard() public {
+        uint256 withdrawAmount = usdcDeposit.balance();
+        uint256 daiStartingBalance = daiDeposit.balance();
+
+        vm.prank(pcvGuard);
+        compoundRouter.swapUsdcForDai(withdrawAmount); /// withdraw all balance
+
+        assertApproxEq(
+            daiDeposit.balance().toInt256(),
+            (withdrawAmount * USDC_SCALING_FACTOR + daiStartingBalance)
+                .toInt256(),
+            0
+        );
+        assertTrue(usdcDeposit.balance() < 1e6); /// assert only dust remains
     }
 
-    function testSwapDaiToUsdcSucceedsCompPCVMover() public {
-        vm.prank(compoundPCVMover);
+    function testSwapDaiToUsdcSucceedsPCVGuard() public {
+        uint256 withdrawAmount = daiDeposit.balance();
+        uint256 usdcStartingBalance = usdcDeposit.balance();
+
+        vm.prank(pcvGuard);
+        compoundRouter.swapDaiForUsdc(withdrawAmount); /// withdraw all balance
+
+        assertApproxEq(
+            usdcDeposit.balance().toInt256(),
+            (withdrawAmount / USDC_SCALING_FACTOR + usdcStartingBalance)
+                .toInt256(),
+            0
+        );
+        assertTrue(daiDeposit.balance() < 1e18); /// assert only dust remains
     }
 
-    function testSwapUsdcToDaiFailsNoLiquidity() public {}
+    function testSwapUsdcToDaiFailsNoLiquidity() public {
+        uint256 withdrawAmount = usdcDeposit.balance();
+        vm.startPrank(pcvGuard);
+        pcvGuardian.withdrawAllToSafeAddress(address(usdcDeposit)); /// pull all funds from usdc pcv deposit
+        vm.expectRevert("CompoundPCVDeposit: redeem error"); /// CUSDC has old cToken implementation that fails without reverting
+        compoundRouter.swapUsdcForDai(withdrawAmount); /// withdraw all balance
+        vm.stopPrank();
+    }
 
-    function testSwapDaiToUsdcFailsNoLiquidity() public {}
+    function testSwapDaiToUsdcFailsNoLiquidity() public {
+        uint256 withdrawAmount = daiDeposit.balance();
+        vm.startPrank(pcvGuard);
+        pcvGuardian.withdrawAllToSafeAddress(address(daiDeposit)); /// pull all funds from dai pcv deposit
+        vm.expectRevert(stdError.arithmeticError); /// CDAI has new cToken implementation that fails with a revert
+        compoundRouter.swapDaiForUsdc(withdrawAmount); /// withdraw all balance
+        vm.stopPrank();
+    }
 
-    function testSwapUsdcToDaiFailsUnauthorized() public {}
+    function testSwapUsdcToDaiFailsUnauthorized() public {
+        uint256 withdrawAmount = usdcDeposit.balance();
+        vm.expectRevert("UNAUTHORIZED");
+        compoundRouter.swapUsdcForDai(withdrawAmount);
+    }
 
-    function testSwapDaiToUsdcFailsUnauthorized() public {}
+    function testSwapDaiToUsdcFailsUnauthorized() public {
+        uint256 withdrawAmount = daiDeposit.balance();
+        vm.expectRevert("UNAUTHORIZED");
+        compoundRouter.swapDaiForUsdc(withdrawAmount);
+    }
 }

--- a/contracts/test/integration/compound/IntegrationTestCompoundPCVRouter.t.sol
+++ b/contracts/test/integration/compound/IntegrationTestCompoundPCVRouter.t.sol
@@ -1,0 +1,141 @@
+pragma solidity ^0.8.4;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import {Vm} from "../../unit/utils/Vm.sol";
+import {DSTest} from "../../unit/utils/DSTest.sol";
+import {CompoundPCVRouter} from "../../../pcv/compound/CompoundPCVRouter.sol";
+import {ERC20CompoundPCVDeposit} from "../../../pcv/compound/ERC20CompoundPCVDeposit.sol";
+import {Core} from "../../../core/Core.sol";
+import {TribeRoles} from "../../../core/TribeRoles.sol";
+import {MockERC20} from "../../../mock/MockERC20.sol";
+import {MainnetAddresses} from "../fixtures/MainnetAddresses.sol";
+import {ArbitrumAddresses} from "../fixtures/ArbitrumAddresses.sol";
+
+contract CompoundPCVRouterIntegrationTest is DSTest {
+    using SafeCast for *;
+
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+
+    Core private core = Core(MainnetAddresses.CORE);
+    IERC20 private usdc = IERC20(MainnetAddresses.USDC);
+    IERC20 private dai = IERC20(MainnetAddresses.DAI);
+    address private governor = MainnetAddresses.GOVERNOR;
+
+    CompoundPCVRouter private compoundRouter;
+    ERC20CompoundPCVDeposit private daiDeposit;
+    ERC20CompoundPCVDeposit private usdcDeposit;
+
+    uint256 public constant depositAmount = 10_000_000e18;
+    address public constant compoundPCVMover = address(1);
+
+    /// @notice scaling factor for USDC
+    uint256 public constant USDC_SCALING_FACTOR = 1e12;
+
+    function setUp() public {
+        daiDeposit = new ERC20CompoundPCVDeposit(
+            address(core),
+            MainnetAddresses.CDAI
+        );
+
+        usdcDeposit = new ERC20CompoundPCVDeposit(
+            address(core),
+            MainnetAddresses.CUSDC
+        );
+
+        compoundRouter = new CompoundPCVRouter(
+            address(core),
+            MainnetAddresses.MAKER_DAI_USDC_PSM,
+            daiDeposit,
+            usdcDeposit
+        );
+
+        /// role setup
+        vm.prank(governor);
+        core.grantPCVController(address(compoundRouter));
+
+        /// get funding for PCV Deposits
+        vm.startPrank(MainnetAddresses.DAI_USDC_USDT_CURVE_POOL);
+        dai.transfer(address(daiDeposit), depositAmount);
+        usdc.transfer(
+            address(usdcDeposit),
+            depositAmount / USDC_SCALING_FACTOR
+        );
+        vm.stopPrank();
+
+        daiDeposit.deposit();
+        usdcDeposit.deposit();
+    }
+
+    function testSetup() public {
+        /// cToken share price rounds down against depositors,
+        /// this means balance is a hair under deposit amount
+        assertApproxEq(
+            daiDeposit.balance().toInt256(),
+            depositAmount.toInt256(),
+            0
+        );
+        assertApproxEq(
+            usdcDeposit.balance().toInt256(),
+            (depositAmount / USDC_SCALING_FACTOR).toInt256(),
+            0
+        );
+
+        assertTrue(core.isPCVController(address(compoundRouter)));
+
+        assertEq(
+            address(compoundRouter.daiPSM()),
+            MainnetAddresses.MAKER_DAI_USDC_PSM
+        );
+        assertEq(address(compoundRouter.daiPcvDeposit()), address(daiDeposit));
+        assertEq(
+            address(compoundRouter.usdcPcvDeposit()),
+            address(usdcDeposit)
+        );
+    }
+
+    function testSwapDaiToUsdcSucceeds() public {
+        uint256 withdrawAmount = daiDeposit.balance();
+
+        vm.prank(governor);
+        compoundRouter.swapDaiForUsdc(withdrawAmount); /// withdraw all balance
+
+        assertApproxEq(
+            usdcDeposit.balance().toInt256(),
+            ((withdrawAmount * 2) / USDC_SCALING_FACTOR).toInt256(),
+            0
+        );
+        assertTrue(daiDeposit.balance() < 1e9); /// assert only dust remains
+    }
+
+    function testSwapUsdcToDaiSucceeds() public {
+        uint256 withdrawAmount = usdcDeposit.balance();
+
+        vm.prank(governor);
+        compoundRouter.swapUsdcForDai(withdrawAmount); /// withdraw all balance
+
+        assertApproxEq(
+            daiDeposit.balance().toInt256(),
+            (depositAmount * 2).toInt256(),
+            0
+        );
+        assertTrue(usdcDeposit.balance() < 1e3); /// assert only dust remains
+    }
+
+    function testSwapUsdcToDaiSucceedsCompPCVMover() public {
+        vm.prank(compoundPCVMover);
+    }
+
+    function testSwapDaiToUsdcSucceedsCompPCVMover() public {
+        vm.prank(compoundPCVMover);
+    }
+
+    function testSwapUsdcToDaiFailsNoLiquidity() public {}
+
+    function testSwapDaiToUsdcFailsNoLiquidity() public {}
+
+    function testSwapUsdcToDaiFailsUnauthorized() public {}
+
+    function testSwapDaiToUsdcFailsUnauthorized() public {}
+}

--- a/contracts/test/integration/fixtures/MainnetAddresses.sol
+++ b/contracts/test/integration/fixtures/MainnetAddresses.sol
@@ -43,8 +43,12 @@ library MainnetAddresses {
     address public constant TIMELOCK_CONTROLLER =
         0x75d078248eE49c585b73E73ab08bb3eaF93383Ae;
 
+    /// contracts that are routers and interact with maker routers
     address public constant MAKER_ROUTER =
         0xC403da9AaC46d3AdcD1a1bBe774601C0ddc542F7;
+
+    address public constant COMPOUND_PCV_ROUTER =
+        0x6338Ec144279b1f05AF8C90216d90C5b54Fa4D8F;
 
     /// current active EOA's
     address public constant OTC_LOAN_REPAYMENT =
@@ -101,6 +105,8 @@ library MainnetAddresses {
 
     address public constant MAKER_DAI_USDC_PSM =
         0x89B78CfA322F6C5dE0aBcEecab66Aee45393cC5A;
+    address public constant GEM_JOIN =
+        0x0A59649758aa4d66E25f08Dd01271e891fe52199;
 
     // ---------- CHAINLINK ADDRESSES ----------
 

--- a/contracts/test/integration/vip/Runner.sol
+++ b/contracts/test/integration/vip/Runner.sol
@@ -36,16 +36,16 @@ contract Runner is TimelockSimulation, vip12 {
     }
 
     function testProposalArbitrum() public {
-        arbitrumSetup();
-        simulate(
-            getArbitrumProposal(),
-            TimelockController(payable(ArbitrumAddresses.TIMELOCK_CONTROLLER)),
-            arbitrumPCVGuardian,
-            ArbitrumAddresses.GOVERNOR,
-            ArbitrumAddresses.EOA_1,
-            vm,
-            true
-        );
-        arbitrumValidate();
+        // arbitrumSetup();
+        // simulate(
+        //     getArbitrumProposal(),
+        //     TimelockController(payable(ArbitrumAddresses.TIMELOCK_CONTROLLER)),
+        //     arbitrumPCVGuardian,
+        //     ArbitrumAddresses.GOVERNOR,
+        //     ArbitrumAddresses.EOA_1,
+        //     vm,
+        //     true
+        // );
+        // arbitrumValidate();
     }
 }

--- a/contracts/test/integration/vip/Runner.sol
+++ b/contracts/test/integration/vip/Runner.sol
@@ -1,6 +1,6 @@
 pragma solidity =0.8.13;
 
-import {vip11} from "./vip11.sol";
+import {vip12} from "./vip12.sol";
 // import {vipx} from "./vipx.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {TimelockSimulation} from "../utils/TimelockSimulation.sol";
@@ -10,7 +10,7 @@ import {PCVGuardian} from "./../../../pcv/PCVGuardian.sol";
 
 /// @dev test harness for running and simulating VOLT Improvement Proposals
 /// inherit the proposal to simulate
-contract Runner is TimelockSimulation, vip11 {
+contract Runner is TimelockSimulation, vip12 {
     /// @notice mainnet PCV Guardian
     PCVGuardian private immutable mainnetPCVGuardian =
         PCVGuardian(MainnetAddresses.PCV_GUARDIAN);

--- a/contracts/test/integration/vip/vip12.sol
+++ b/contracts/test/integration/vip/vip12.sol
@@ -1,0 +1,78 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity =0.8.13;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import {Vm} from "./../../unit/utils/Vm.sol";
+import {Core} from "../../../core/Core.sol";
+import {IVIP} from "./IVIP.sol";
+import {DSTest} from "./../../unit/utils/DSTest.sol";
+import {PCVGuardian} from "../../../pcv/PCVGuardian.sol";
+import {MainnetAddresses} from "../fixtures/MainnetAddresses.sol";
+import {OraclePassThrough} from "../../../oracle/OraclePassThrough.sol";
+import {PegStabilityModule} from "../../../peg/PegStabilityModule.sol";
+import {ITimelockSimulation} from "../utils/ITimelockSimulation.sol";
+import {ERC20CompoundPCVDeposit} from "../../../pcv/compound/ERC20CompoundPCVDeposit.sol";
+
+contract vip12 is DSTest, IVIP {
+    using SafeERC20 for IERC20;
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+
+    address private fei = MainnetAddresses.FEI;
+    address private core = MainnetAddresses.CORE;
+
+    OraclePassThrough private mainnetOPT =
+        OraclePassThrough(MainnetAddresses.ORACLE_PASS_THROUGH);
+
+    ITimelockSimulation.action[] private mainnetProposal;
+
+    constructor() {
+        mainnetProposal.push(
+            ITimelockSimulation.action({
+                value: 0,
+                target: MainnetAddresses.CORE,
+                arguments: abi.encodeWithSignature(
+                    "grantPCVController(address)"
+                    // MainnetAddresses.COMPOUND_PCV_ROUTER TODO on deployment
+                ),
+                description: "Grant PCV Controller to Compound PCV Router"
+            })
+        );
+    }
+
+    function getMainnetProposal()
+        public
+        view
+        override
+        returns (ITimelockSimulation.action[] memory)
+    {
+        return mainnetProposal;
+    }
+
+    function mainnetSetup() public override {}
+
+    /// TODO on deployment
+    /// assert compound pcv router has pcv controller role
+    /// assert all variables are correclty set in compound pcv router
+    function mainnetValidate() public override {}
+
+    function getArbitrumProposal()
+        public
+        view
+        override
+        returns (ITimelockSimulation.action[] memory)
+    {
+        revert("No Arbitrum proposal");
+    }
+
+    function arbitrumSetup() public override {
+        revert("No Arbitrum proposal");
+    }
+
+    /// assert oracle pass through is pointing to correct volt system oracle
+    function arbitrumValidate() public override {
+        revert("No Arbitrum proposal");
+    }
+}

--- a/contracts/test/integration/vip/vip12.sol
+++ b/contracts/test/integration/vip/vip12.sol
@@ -37,7 +37,7 @@ contract vip12 is DSTest, IVIP {
                     "grantPCVController(address)"
                     // MainnetAddresses.COMPOUND_PCV_ROUTER TODO on deployment
                 ),
-                description: "Grant PCV Controller to Compound PCV Router"
+                description: "Grant Compound PCV Router the PCV Controller Role"
             })
         );
     }

--- a/proposals/dao/vip_12.ts
+++ b/proposals/dao/vip_12.ts
@@ -29,7 +29,6 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
 
   const compoundPCVRouter = await compoundPCVRouterOracleFactory.deploy(
     addresses.core,
-    addresses.makerDaiUsdcPSM,
     addresses.daiCompoundPCVDeposit,
     addresses.usdcCompoundPCVDeposit
   );

--- a/proposals/dao/vip_12.ts
+++ b/proposals/dao/vip_12.ts
@@ -1,0 +1,71 @@
+import {
+  DeployUpgradeFunc,
+  NamedAddresses,
+  SetupUpgradeFunc,
+  TeardownUpgradeFunc,
+  ValidateUpgradeFunc
+} from '@custom-types/types';
+import config from '../../scripts/config';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+const { STARTING_ORACLE_PRICE, ORACLE_PERIOD_START_TIME, MONTHLY_CHANGE_RATE_BASIS_POINTS } = config;
+
+/*
+
+Volt Protocol Improvement Proposal #12
+
+Description: Create Compound PCV Router and grant it the PCV Controller role
+
+Steps:
+  1 - Deploy Compound PCV Router
+  2 - Grant newly deployed compound pcv router the PCV Controller role
+
+*/
+
+const vipNumber = '12';
+
+const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: NamedAddresses, logging: boolean) => {
+  const compoundPCVRouterOracleFactory = await ethers.getContractFactory('CompoundPCVRouter');
+
+  const compoundPCVRouter = await compoundPCVRouterOracleFactory.deploy(
+    addresses.core,
+    addresses.makerDaiUsdcPSM,
+    addresses.daiCompoundPCVDeposit,
+    addresses.usdcCompoundPCVDeposit
+  );
+
+  await compoundPCVRouter.deployed();
+
+  console.log(`Compound PCV Router ${compoundPCVRouter.address}`);
+
+  console.log(`Deployed Compound PCV Router VIP-${vipNumber}`);
+  return {
+    compoundPCVRouter
+  };
+};
+
+const setup: SetupUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {};
+
+// Tears down any changes made in setup() that need to be
+// cleaned up before doing any validation checks.
+const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {};
+
+// Run any validations required on the vip using mocha or console logging
+// IE check balances, check state of contracts, etc.
+const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  const { compoundPCVRouter, core } = contracts;
+
+  expect(await core.isPCVController(compoundPCVRouter.address)).to.be.true;
+
+  expect(await compoundPCVRouter.core()).to.be.equal(addresses.core);
+  expect(await compoundPCVRouter.USDC()).to.be.equal(addresses.usdc);
+  expect(await compoundPCVRouter.DAI()).to.be.equal(addresses.dai);
+  expect(await compoundPCVRouter.daiPcvDeposit()).to.be.equal(addresses.daiCompoundPCVDeposit);
+  expect(await compoundPCVRouter.usdcPcvDeposit()).to.be.equal(addresses.usdcCompoundPCVDeposit);
+  expect(await compoundPCVRouter.daiPSM()).to.be.equal(addresses.makerDaiUsdcPSM);
+  expect(await compoundPCVRouter.GEM_JOIN()).to.be.equal(addresses.makerGemJoin);
+
+  console.log(`Successfully validated VIP-${vipNumber}`);
+};
+
+export { deploy, setup, teardown, validate };

--- a/proposals/vip_12.ts
+++ b/proposals/vip_12.ts
@@ -1,0 +1,17 @@
+import { ProposalDescription } from '@custom-types/types';
+
+const vip_12: ProposalDescription = {
+  title: 'VIP-12: Compound PCV Router',
+  commands: [
+    {
+      target: 'core',
+      values: '0',
+      method: 'grantPCVController(address)',
+      arguments: ['{compoundPCVRouter}'],
+      description: 'Grant Compound PCV Router the PCV Controller Role'
+    }
+  ],
+  description: 'VIP-12 Grant Compound PCV Router the PCV Controller Role'
+};
+
+export default vip_12;

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -118,6 +118,12 @@ const MainnetAddresses: MainnetAddresses = {
     category: AddressCategory.PCV,
     network: Network.Mainnet
   },
+  compoundPCVRouter: {
+    address: '0x6338Ec144279b1f05AF8C90216d90C5b54Fa4D8F',
+    artifactName: 'CompoundPCVRouter',
+    category: AddressCategory.PCV,
+    network: Network.Mainnet
+  },
   erc20Allocator: {
     address: '0x37518BbE48fEaE49ECBD83F7e9C01c1A6b4c2F69',
     artifactName: 'ERC20Allocator',

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -161,6 +161,12 @@ const MainnetAddresses: MainnetAddresses = {
     category: AddressCategory.External,
     network: Network.Mainnet
   },
+  makerGemJoin: {
+    address: '0x0A59649758aa4d66E25f08Dd01271e891fe52199',
+    artifactName: 'unknown',
+    category: AddressCategory.External,
+    network: Network.Mainnet
+  },
   feiDaiFixedPricePSM: {
     address: '0x2A188F9EB761F70ECEa083bA6c2A40145078dfc2',
     artifactName: 'unknown', /// Fixed Price PSM


### PR DESCRIPTION
This contracts allows for swaps between cDAI and cUSDC by using the Maker DAI-USDC PSM. It is permissioned to only allow the governor, PCV controller and the PCV guard to be able to trigger rebalances in these venues.

Attack vectors to check for reviewers:
- [x] Theft of PCV
- [x] Unauthorized rebalancing
- [x] Incorrect hardcoded smart contract address
- [x] Insufficient Integration Tests

Todo:
- [x] Deployment Script
- [x] Governance Script
- [x] Deploy to mainnet

Audit Log:
- 9/20 Reviewed by Kassim, found mismatch in calldata descriptions between solidity and typescript. Fixed immediately
- 9/20 Reviewed by Erwan, found low probability issue where this PSM doesn't assert proper balances after a swap, meaning if fees are turned on, then this rebalance would lose the protocol money.
- 9/20 During review, I added checks to ensure that tin and tout (mint and redeem fees on the dai psm) were set to 0, if they aren't set to 0, things fail.
- 9/20 Reviewed by Kyle, described why integration tests had such a large amount of dust left in pcv deposits. Fixed this by accruing interest on the CTokens in the setup function of the integration tests. Added additional integration tests on the call to set tin and tout to 1 and ensure that swaps fail when fees are non zero.
- 9/20 Deployed to mainnet and verified smart contracts on etherscan.
- 9/20 Reviewed by Tom, only comment was that we could add events, other than that, no additional comments or issues.