### PR TITLE
VIP-14-A Arbitrum Deprecation Proposal

### DIFF
--- a/contracts/test/integration/fixtures/ArbitrumAddresses.sol
+++ b/contracts/test/integration/fixtures/ArbitrumAddresses.sol
@@ -5,14 +5,18 @@ library ArbitrumAddresses {
     // ---------- VOLT ADDRESSES ----------
     address public constant CORE = 0x31A38B79fDcFBC3095E3268CAFac1b9791796736;
     address public constant VOLT = 0x6Ba6f18a290Cd55cf1B00be2bEc5c954cb29fAc5;
+
+    /// ---------- CURRENT ORACLES ----------
     address public constant ORACLE_PASS_THROUGH =
         0xcd836280e4416e08F54E5584Bcd49Ac2E3a68747;
+    address public constant VOLT_SYSTEM_ORACLE_0_BIPS =
+        0xACce8F8661f7f214b94f94e3e1A09d81f0B924D6;
+
+    /// deprecated oracles
     address public constant VOLT_SYSTEM_ORACLE =
         0x69DBf8dD98Aa40F50E4f2263c6f2d66f26f9cb5b;
     address public constant VOLT_SYSTEM_ORACLE_144_BIPS =
         0x5DDf983CbD5819c13661046110EfCd2E8629d40b;
-
-    /// deprecated oracles
     address public constant DEPRECATED_ORACLE_PASS_THROUGH =
         0x7A23eB9bf043471dE7422a9CcdB5Ef809F34CbdE;
     address public constant DEPRECATED_SCALING_PRICE_ORACLE =

--- a/contracts/test/integration/utils/MintRedeemVerification.sol
+++ b/contracts/test/integration/utils/MintRedeemVerification.sol
@@ -44,6 +44,10 @@ contract MintRedeemVerification {
         IERC20 volt,
         uint256 amountVoltIn
     ) private {
+        if (psm.paused() || psm.redeemPaused()) {
+            return;
+        }
+
         uint256 startingUserUnderlyingBalance = underlying.balanceOf(
             address(this)
         );
@@ -96,6 +100,16 @@ contract MintRedeemVerification {
         uint256 amountUnderlyingIn,
         bool doLogging
     ) private {
+        if (psm.paused() || psm.mintPaused()) {
+            if (doLogging) {
+                console.log(
+                    "not verifying psm minting, paused: ",
+                    address(psm)
+                );
+            }
+            return;
+        }
+
         uint256 startingUserVoltBalance = volt.balanceOf(address(this));
         uint256 startingUserDaiBalance = underlying.balanceOf(address(this));
         uint256 startingPSMVoltBalance = volt.balanceOf(address(psm));
@@ -183,10 +197,6 @@ contract MintRedeemVerification {
     }
 
     function doMint(Vm vm, bool doLogging) external {
-        if (block.chainid != 1) {
-            revert("successfully minted on all PSMs");
-        }
-
         address[] storage allPSMs = block.chainid == 1
             ? allMainnetPSMs
             : allArbitrumPSMs;

--- a/contracts/test/integration/utils/MintRedeemVerification.sol
+++ b/contracts/test/integration/utils/MintRedeemVerification.sol
@@ -183,6 +183,10 @@ contract MintRedeemVerification {
     }
 
     function doMint(Vm vm, bool doLogging) external {
+        if (block.chainid != 1) {
+            revert("successfully minted on all PSMs");
+        }
+
         address[] storage allPSMs = block.chainid == 1
             ? allMainnetPSMs
             : allArbitrumPSMs;

--- a/contracts/test/integration/vip/Runner.sol
+++ b/contracts/test/integration/vip/Runner.sol
@@ -1,6 +1,6 @@
 pragma solidity =0.8.13;
 
-import {vip12} from "./vip12.sol";
+import {vip14a} from "./vip14a.sol";
 // import {vipx} from "./vipx.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
 import {TimelockSimulation} from "../utils/TimelockSimulation.sol";
@@ -10,7 +10,7 @@ import {PCVGuardian} from "./../../../pcv/PCVGuardian.sol";
 
 /// @dev test harness for running and simulating VOLT Improvement Proposals
 /// inherit the proposal to simulate
-contract Runner is TimelockSimulation, vip12 {
+contract Runner is TimelockSimulation, vip14a {
     /// @notice mainnet PCV Guardian
     PCVGuardian private immutable mainnetPCVGuardian =
         PCVGuardian(MainnetAddresses.PCV_GUARDIAN);
@@ -22,30 +22,30 @@ contract Runner is TimelockSimulation, vip12 {
     /// remove all function calls inside testProposal and don't inherit the VIP
     /// once the proposal is live and passed
     function testProposalMainnet() public {
-        mainnetSetup();
-        simulate(
-            getMainnetProposal(),
-            TimelockController(payable(MainnetAddresses.TIMELOCK_CONTROLLER)),
-            mainnetPCVGuardian,
-            MainnetAddresses.GOVERNOR,
-            MainnetAddresses.EOA_1,
-            vm,
-            true
-        );
-        mainnetValidate();
-    }
-
-    function testProposalArbitrum() public {
-        // arbitrumSetup();
+        // mainnetSetup();
         // simulate(
-        //     getArbitrumProposal(),
-        //     TimelockController(payable(ArbitrumAddresses.TIMELOCK_CONTROLLER)),
-        //     arbitrumPCVGuardian,
-        //     ArbitrumAddresses.GOVERNOR,
-        //     ArbitrumAddresses.EOA_1,
+        //     getMainnetProposal(),
+        //     TimelockController(payable(MainnetAddresses.TIMELOCK_CONTROLLER)),
+        //     mainnetPCVGuardian,
+        //     MainnetAddresses.GOVERNOR,
+        //     MainnetAddresses.EOA_1,
         //     vm,
         //     true
         // );
-        // arbitrumValidate();
+        // mainnetValidate();
+    }
+
+    function testProposalArbitrum() public {
+        arbitrumSetup();
+        simulate(
+            getArbitrumProposal(),
+            TimelockController(payable(ArbitrumAddresses.TIMELOCK_CONTROLLER)),
+            arbitrumPCVGuardian,
+            ArbitrumAddresses.GOVERNOR,
+            ArbitrumAddresses.EOA_1,
+            vm,
+            true
+        );
+        arbitrumValidate();
     }
 }

--- a/contracts/test/integration/vip/vip14a.sol
+++ b/contracts/test/integration/vip/vip14a.sol
@@ -1,0 +1,165 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity =0.8.13;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import {Vm} from "./../../unit/utils/Vm.sol";
+import {Core} from "../../../core/Core.sol";
+import {IVIP} from "./IVIP.sol";
+import {DSTest} from "./../../unit/utils/DSTest.sol";
+import {PCVDeposit} from "../../../pcv/PCVDeposit.sol";
+import {PCVGuardian} from "../../../pcv/PCVGuardian.sol";
+import {IPCVDeposit} from "../../../pcv/IPCVDeposit.sol";
+import {PriceBoundPSM} from "../../../peg/PriceBoundPSM.sol";
+import {VoltSystemOracle} from "../../../oracle/VoltSystemOracle.sol";
+import {ArbitrumAddresses} from "../fixtures/ArbitrumAddresses.sol";
+import {OraclePassThrough} from "../../../oracle/OraclePassThrough.sol";
+import {CompoundPCVRouter} from "../../../pcv/compound/CompoundPCVRouter.sol";
+import {ITimelockSimulation} from "../utils/ITimelockSimulation.sol";
+
+/// VIP 14-A
+/// This VIP is the first step in Arbitrum deprecation. It pauses minting
+/// on the Arbitrum PSM and sets the oracle to a constant price oracle
+/// that does not compound interest.
+
+/// Deployment Steps
+/// 1. deploy volt system oracle
+
+/// Governance Steps
+/// 1. connect new oracle to oracle pass through with updated rate
+/// 2. disable minting on USDC PSM
+/// 3. disable minting on DAI PSM
+
+contract vip14a is DSTest, IVIP {
+    using SafeERC20 for IERC20;
+
+    Vm public constant vm = Vm(HEVM_ADDRESS);
+
+    ITimelockSimulation.action[] private arbitrumProposal;
+
+    VoltSystemOracle public oracle;
+
+    uint256 public startTime;
+    uint256 public startPrice;
+
+    uint256 public constant monthlyChangeRateBasisPoints = 0;
+
+    PCVGuardian public immutable pcvGuardian =
+        PCVGuardian(ArbitrumAddresses.PCV_GUARDIAN);
+
+    OraclePassThrough public immutable opt =
+        OraclePassThrough(ArbitrumAddresses.ORACLE_PASS_THROUGH);
+
+    constructor() {
+        if (block.chainid == 1) {
+            return;
+        }
+
+        startPrice = VoltSystemOracle(
+            ArbitrumAddresses.VOLT_SYSTEM_ORACLE_144_BIPS
+        ).getCurrentOraclePrice();
+        startTime = block.timestamp;
+
+        oracle = new VoltSystemOracle(
+            monthlyChangeRateBasisPoints,
+            block.timestamp,
+            VoltSystemOracle(ArbitrumAddresses.VOLT_SYSTEM_ORACLE_144_BIPS)
+                .getCurrentOraclePrice()
+        );
+
+        arbitrumProposal.push(
+            ITimelockSimulation.action({
+                value: 0,
+                target: ArbitrumAddresses.ORACLE_PASS_THROUGH,
+                arguments: abi.encodeWithSignature(
+                    "updateScalingPriceOracle(address)",
+                    address(oracle)
+                ),
+                description: "Point Oracle Pass Through to new oracle address"
+            })
+        );
+        arbitrumProposal.push(
+            ITimelockSimulation.action({
+                value: 0,
+                target: ArbitrumAddresses.VOLT_USDC_PSM,
+                arguments: abi.encodeWithSignature("pauseMint()"),
+                description: "Pause minting on USDC PSM on Arbitrum"
+            })
+        );
+        arbitrumProposal.push(
+            ITimelockSimulation.action({
+                value: 0,
+                target: ArbitrumAddresses.VOLT_DAI_PSM,
+                arguments: abi.encodeWithSignature("pauseMint()"),
+                description: "Pause minting on DAI PSM on Arbitrum"
+            })
+        );
+    }
+
+    function getMainnetProposal()
+        public
+        view
+        override
+        returns (ITimelockSimulation.action[] memory)
+    {}
+
+    function mainnetSetup() public override {
+        revert("no mainnet setup actions");
+    }
+
+    function mainnetValidate() public override {
+        revert("no mainnet validate actions");
+    }
+
+    function getArbitrumProposal()
+        public
+        view
+        override
+        returns (ITimelockSimulation.action[] memory)
+    {
+        return arbitrumProposal;
+    }
+
+    /// no-op, nothing to setup
+    function arbitrumSetup() public override {}
+
+    /// assert oracle pass through is pointing to correct volt system oracle
+    function arbitrumValidate() public override {
+        /// oracle pass through points to new scaling price oracle
+        assertEq(
+            address(
+                OraclePassThrough(ArbitrumAddresses.ORACLE_PASS_THROUGH)
+                    .scalingPriceOracle()
+            ),
+            address(oracle)
+        );
+        assertEq(
+            oracle.monthlyChangeRateBasisPoints(),
+            monthlyChangeRateBasisPoints
+        );
+        assertEq(oracle.monthlyChangeRateBasisPoints(), 0); /// pause rate updates to Volt on Arbitrum
+        assertEq(oracle.periodStartTime(), startTime);
+        assertEq(opt.getCurrentOraclePrice(), startPrice);
+        assertEq(oracle.oraclePrice(), startPrice);
+
+        assertTrue(PriceBoundPSM(ArbitrumAddresses.VOLT_USDC_PSM).mintPaused());
+        assertTrue(PriceBoundPSM(ArbitrumAddresses.VOLT_DAI_PSM).mintPaused());
+
+        vm.expectRevert("PegStabilityModule: Minting paused");
+        PriceBoundPSM(ArbitrumAddresses.VOLT_USDC_PSM).mint(
+            address(this),
+            0,
+            0
+        );
+
+        vm.expectRevert("PegStabilityModule: Minting paused");
+        PriceBoundPSM(ArbitrumAddresses.VOLT_DAI_PSM).mint(address(this), 0, 0);
+        vm.warp(block.timestamp + 100 days);
+
+        oracle.compoundInterest();
+        assertEq(opt.getCurrentOraclePrice(), startPrice);
+        assertEq(oracle.oraclePrice(), startPrice);
+    }
+}

--- a/contracts/test/integration/vip/vip14a.sol
+++ b/contracts/test/integration/vip/vip14a.sol
@@ -39,10 +39,11 @@ contract vip14a is DSTest, IVIP {
 
     ITimelockSimulation.action[] private arbitrumProposal;
 
-    VoltSystemOracle public oracle;
+    VoltSystemOracle public oracle =
+        VoltSystemOracle(ArbitrumAddresses.VOLT_SYSTEM_ORACLE_0_BIPS);
 
-    uint256 public startTime;
-    uint256 public startPrice;
+    uint256 public constant startTime = 1665681823;
+    uint256 public startPrice = 1056672647567682146;
 
     uint256 public constant monthlyChangeRateBasisPoints = 0;
 
@@ -56,17 +57,6 @@ contract vip14a is DSTest, IVIP {
         if (block.chainid == 1) {
             return;
         }
-
-        startPrice = VoltSystemOracle(
-            ArbitrumAddresses.VOLT_SYSTEM_ORACLE_144_BIPS
-        ).getCurrentOraclePrice();
-        startTime = block.timestamp;
-
-        oracle = new VoltSystemOracle(
-            monthlyChangeRateBasisPoints,
-            block.timestamp,
-            startPrice
-        );
 
         arbitrumProposal.push(
             ITimelockSimulation.action({

--- a/contracts/test/integration/vip/vip14a.sol
+++ b/contracts/test/integration/vip/vip14a.sol
@@ -77,7 +77,7 @@ contract vip14a is DSTest, IVIP {
                     "updateScalingPriceOracle(address)",
                     address(oracle)
                 ),
-                description: "Point Oracle Pass Through to new oracle address"
+                description: "Point Arbitrum Oracle Pass Through to 0 basis point Volt System Oracle"
             })
         );
         arbitrumProposal.push(

--- a/contracts/test/integration/vip/vip14a.sol
+++ b/contracts/test/integration/vip/vip14a.sol
@@ -65,8 +65,7 @@ contract vip14a is DSTest, IVIP {
         oracle = new VoltSystemOracle(
             monthlyChangeRateBasisPoints,
             block.timestamp,
-            VoltSystemOracle(ArbitrumAddresses.VOLT_SYSTEM_ORACLE_144_BIPS)
-                .getCurrentOraclePrice()
+            startPrice
         );
 
         arbitrumProposal.push(

--- a/proposals/dao/vip_14_arbitrum.ts
+++ b/proposals/dao/vip_14_arbitrum.ts
@@ -23,7 +23,7 @@ Governance Steps:
 /// TODO update this to correct start time
 let startTime;
 
-const monthlyChangeBasisPoints = 0;
+const ZERO_MONTHLY_CHANGE_BASIS_POINTS = 0;
 
 const vipNumber = '14';
 
@@ -36,7 +36,11 @@ const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: Named
 
   const voltSystemOracleFactory = await ethers.getContractFactory('VoltSystemOracle');
 
-  const voltSystemOracle0Bips = await voltSystemOracleFactory.deploy(monthlyChangeBasisPoints, startTime, currentPrice);
+  const voltSystemOracle0Bips = await voltSystemOracleFactory.deploy(
+    ZERO_MONTHLY_CHANGE_BASIS_POINTS,
+    startTime,
+    currentPrice
+  );
   await voltSystemOracle0Bips.deployed();
 
   console.log(`Volt System Oracle deployed ${voltSystemOracle0Bips.address}`);

--- a/proposals/dao/vip_14_arbitrum.ts
+++ b/proposals/dao/vip_14_arbitrum.ts
@@ -30,12 +30,10 @@ const ZERO_MONTHLY_CHANGE_BASIS_POINTS = 0;
 
 const vipNumber = '14';
 
+const currentPrice = '1056672647567682146';
+
 const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: NamedAddresses, logging: boolean) => {
   startTime = Math.floor(Date.now() / 1000).toString();
-
-  const voltSystemOracle = await ethers.getContractAt('VoltSystemOracle', addresses.arbitrumVoltSystemOracle);
-
-  const currentPrice = await voltSystemOracle.getCurrentOraclePrice();
 
   const voltSystemOracleFactory = await ethers.getContractFactory('VoltSystemOracle');
 

--- a/proposals/dao/vip_14_arbitrum.ts
+++ b/proposals/dao/vip_14_arbitrum.ts
@@ -10,17 +10,20 @@ import { ethers } from 'hardhat';
 import { assertApproxEq } from '@test/helpers';
 
 /*
+
 Arbitrum Volt Protocol Improvement Proposal #14
-Description: 
+
 Deployment Steps
 1. deploy volt system oracle with 0 monthlyChangeRateBasisPoints
 Governance Steps:
+
+Governance Steps
 1. Point Oracle Pass Through to new oracle address
-2. Pause DAI PSM
-3. Pause USDC PSM
+2. Pause minting DAI PSM
+3. Pause minting USDC PSM
+
 */
 
-/// TODO update this to correct start time
 let startTime;
 
 const ZERO_MONTHLY_CHANGE_BASIS_POINTS = 0;

--- a/proposals/dao/vip_14_arbitrum.ts
+++ b/proposals/dao/vip_14_arbitrum.ts
@@ -1,0 +1,102 @@
+import {
+  DeployUpgradeFunc,
+  NamedAddresses,
+  SetupUpgradeFunc,
+  TeardownUpgradeFunc,
+  ValidateUpgradeFunc
+} from '@custom-types/types';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { assertApproxEq } from '@test/helpers';
+
+/*
+Arbitrum Volt Protocol Improvement Proposal #14
+Description: 
+Deployment Steps
+1. deploy volt system oracle with 0 monthlyChangeRateBasisPoints
+Governance Steps:
+1. Point Oracle Pass Through to new oracle address
+2. Pause DAI PSM
+3. Pause USDC PSM
+*/
+
+/// TODO update this to correct start time
+let startTime;
+
+const monthlyChangeBasisPoints = 0;
+
+const vipNumber = '14';
+
+const deploy: DeployUpgradeFunc = async (deployAddress: string, addresses: NamedAddresses, logging: boolean) => {
+  startTime = Math.floor(Date.now() / 1000).toString();
+
+  const voltSystemOracle = await ethers.getContractAt('VoltSystemOracle', addresses.arbitrumVoltSystemOracle);
+
+  const currentPrice = await voltSystemOracle.getCurrentOraclePrice();
+
+  const voltSystemOracleFactory = await ethers.getContractFactory('VoltSystemOracle');
+
+  const voltSystemOracle0Bips = await voltSystemOracleFactory.deploy(monthlyChangeBasisPoints, startTime, currentPrice);
+  await voltSystemOracle0Bips.deployed();
+
+  console.log(`Volt System Oracle deployed ${voltSystemOracle0Bips.address}`);
+
+  console.log(`Successfully Deployed VIP-${vipNumber}`);
+  return {
+    voltSystemOracle0Bips
+  };
+};
+
+const setup: SetupUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {};
+
+// Tears down any changes made in setup() that need to be
+// cleaned up before doing any validation checks.
+const teardown: TeardownUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {};
+
+// Run any validations required on the vip using mocha or console logging
+// IE check balances, check state of contracts, etc.
+const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts, logging) => {
+  const {
+    arbitrumUSDCPSM,
+    arbitrumDAIPSM,
+    arbitrumVoltSystemOracle,
+    arbitrumOraclePassThrough,
+    voltSystemOracle0Bips
+  } = contracts;
+
+  /// oracle pass through validation
+  expect(await arbitrumOraclePassThrough.scalingPriceOracle()).to.be.equal(voltSystemOracle0Bips.address);
+
+  /// PSMs fully paused
+  expect(await arbitrumDAIPSM.mintPaused()).to.be.true;
+  expect(await arbitrumUSDCPSM.mintPaused()).to.be.true;
+
+  /// Volt System Oracle has correct price
+  await assertApproxEq(
+    await voltSystemOracle0Bips.getCurrentOraclePrice(),
+    await arbitrumVoltSystemOracle.getCurrentOraclePrice(),
+    0 /// allow 0 bips of deviation
+  );
+
+  await assertApproxEq(
+    await voltSystemOracle0Bips.oraclePrice(),
+    await arbitrumVoltSystemOracle.getCurrentOraclePrice(),
+    0 /// allow 0 bips of deviation
+  );
+
+  await assertApproxEq(
+    await voltSystemOracle0Bips.oraclePrice(),
+    await arbitrumVoltSystemOracle.getCurrentOraclePrice(),
+    0 /// allow 0 bips of deviation
+  );
+
+  await assertApproxEq(
+    await voltSystemOracle0Bips.getCurrentOraclePrice(),
+    await voltSystemOracle0Bips.oraclePrice(),
+    0
+  );
+
+  console.log(`Successfully validated VIP-${vipNumber}`);
+};
+
+export { deploy, setup, teardown, validate };

--- a/proposals/dao/vip_14_arbitrum.ts
+++ b/proposals/dao/vip_14_arbitrum.ts
@@ -91,11 +91,7 @@ const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts,
     0 /// allow 0 bips of deviation
   );
 
-  await assertApproxEq(
-    await voltSystemOracle0Bips.getCurrentOraclePrice(),
-    await voltSystemOracle0Bips.oraclePrice(),
-    0
-  );
+  expect(await voltSystemOracle0Bips.getCurrentOraclePrice()).to.be.equal(await voltSystemOracle0Bips.oraclePrice());
 
   console.log(`Successfully validated VIP-${vipNumber}`);
 };

--- a/proposals/dao/vip_14_arbitrum.ts
+++ b/proposals/dao/vip_14_arbitrum.ts
@@ -92,12 +92,6 @@ const validate: ValidateUpgradeFunc = async (addresses, oldContracts, contracts,
   );
 
   await assertApproxEq(
-    await voltSystemOracle0Bips.oraclePrice(),
-    await arbitrumVoltSystemOracle.getCurrentOraclePrice(),
-    0 /// allow 0 bips of deviation
-  );
-
-  await assertApproxEq(
     await voltSystemOracle0Bips.getCurrentOraclePrice(),
     await voltSystemOracle0Bips.oraclePrice(),
     0

--- a/proposals/vip_14_arbitrum.ts
+++ b/proposals/vip_14_arbitrum.ts
@@ -1,0 +1,39 @@
+import { ProposalDescription } from '@custom-types/types';
+
+const vip_14_arbitrum: ProposalDescription = {
+  title: 'VIP-14 Arbitrum: Rate Update to 0, Pause PSM Minting',
+  commands: [
+    {
+      target: 'arbitrumOraclePassThrough',
+      values: '0',
+      method: 'updateScalingPriceOracle(address)',
+      arguments: ['{voltSystemOracle0Bips}'],
+      description: 'Point Arbitrum Oracle Pass Through to 0 basis point Volt System Oracle'
+    },
+    {
+      target: 'arbitrumUSDCPSM',
+      values: '0',
+      method: 'pauseMint()',
+      arguments: [],
+      description: 'Pause minting on USDC PSM on Arbitrum'
+    },
+    {
+      target: 'arbitrumDAIPSM',
+      values: '0',
+      method: 'pauseMint()',
+      arguments: [],
+      description: 'Pause minting on DAI PSM on Arbitrum'
+    }
+  ],
+  description: `
+  Deployment Steps
+  1. deploy volt system oracle
+  
+  Governance Steps:
+  1. Point Oracle Pass Through to new oracle address
+  2. Pause minting on USDC PSM on Arbitrum
+  3. Pause minting on DAI PSM on Arbitrum
+  `
+};
+
+export default vip_14_arbitrum;

--- a/protocol-configuration/mainnetAddresses.ts
+++ b/protocol-configuration/mainnetAddresses.ts
@@ -293,8 +293,14 @@ const MainnetAddresses: MainnetAddresses = {
     category: AddressCategory.Governance,
     network: Network.Arbitrum
   },
-  arbitrumVoltSystemOracle: {
+  deprecatedArbitrumVoltSystemOracle: {
     address: '0x5DDf983CbD5819c13661046110EfCd2E8629d40b',
+    artifactName: 'VoltSystemOracle',
+    category: AddressCategory.Deprecated,
+    network: Network.Arbitrum
+  },
+  arbitrumVoltSystemOracle0BasisPoints: {
+    address: '0xACce8F8661f7f214b94f94e3e1A09d81f0B924D6',
     artifactName: 'VoltSystemOracle',
     category: AddressCategory.Oracle,
     network: Network.Arbitrum

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -142,6 +142,21 @@ async function getCore(): Promise<Core> {
   return core;
 }
 
+async function assertApproxEq(
+  actual: string | number | BigNumberish,
+  expected: string | number | BigNumberish,
+  allowableDeviation: string | number | BigNumberish
+): Promise<void> {
+  const actualBN = toBN(actual);
+  const expectedBN = toBN(expected);
+  const allowableDeviationBN = toBN(allowableDeviation);
+
+  const diff = actualBN.sub(expectedBN);
+  const diffBasisPoints = diff.mul('10000').div(actual);
+
+  expect(diffBasisPoints.lte(allowableDeviationBN)).to.be.true;
+}
+
 async function expectApprox(
   actual: string | number | BigNumberish,
   expected: string | number | BigNumberish,
@@ -267,6 +282,7 @@ export {
   increaseTime,
   latestTime,
   expectApprox,
+  assertApproxEq,
   expectApproxAbs,
   deployDevelopmentWeth,
   getImpersonatedSigner,


### PR DESCRIPTION
This VIP is the first step in Arbitrum deprecation. It pauses minting on the Arbitrum PSM and sets the oracle to a constant price oracle that does not compound interest.

Deployment Steps
1. deploy volt system oracle

Governance Steps
1. connect new oracle to oracle pass through with updated rate
2. disable minting on USDC PSM
3. disable minting on DAI PSM

Audit Log:
10/7: Review with Kyle from Arbor
Async Review by Kassim
Async Review by Thomas
10/13: Async Review by Kyle from Arbor verifying calldata + deployed contract