### PR TITLE
Allow running code coverage for unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ package-lock.json
 todo
 out/
 docs/
+lcov.info

--- a/contracts/deployment/SystemDeploy.sol
+++ b/contracts/deployment/SystemDeploy.sol
@@ -22,7 +22,8 @@ import {IScalingPriceOracle} from "../oracle/IScalingPriceOracle.sol";
 import {IPCVDeposit, PCVDeposit} from "../pcv/PCVDeposit.sol";
 import {MorphoCompoundPCVDeposit} from "../pcv/morpho/MorphoCompoundPCVDeposit.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, getVoltAddresses, VoltAddresses, VoltTestAddresses} from "../test/unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../test/unit/utils/TestAddresses.sol";
+import {getCoreV2, getVoltAddresses, VoltAddresses} from "../test/unit/utils/Fixtures.sol";
 
 import "hardhat/console.sol";
 
@@ -51,7 +52,6 @@ import "hardhat/console.sol";
 contract SystemDeploy {
     using SafeCast for *;
 
-    VoltTestAddresses public addresses = getAddresses();
     VoltAddresses public guardianAddresses = getVoltAddresses();
 
     CoreV2 private core;

--- a/contracts/test/integration/IntegrationTestCleanPriceBoundPSM.t.sol
+++ b/contracts/test/integration/IntegrationTestCleanPriceBoundPSM.t.sol
@@ -15,7 +15,8 @@ import {MainnetAddresses} from "./fixtures/MainnetAddresses.sol";
 import {IOraclePassThrough} from "../../oracle/IOraclePassThrough.sol";
 import {PegStabilityModule} from "../../peg/PegStabilityModule.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "./../unit/utils/Fixtures.sol";
 
 import "hardhat/console.sol";
 
@@ -23,8 +24,6 @@ import "hardhat/console.sol";
 /// to ensure parity in behavior
 contract IntegrationTestCleanPriceBoundPSM is DSTest {
     using SafeCast for *;
-
-    VoltTestAddresses public addresses = getAddresses();
 
     /// reference PSM to test against
     PegStabilityModule private immutable priceBoundPsm =

--- a/contracts/test/integration/IntegrationTestDaiCleanPriceBoundPSM.t.sol
+++ b/contracts/test/integration/IntegrationTestDaiCleanPriceBoundPSM.t.sol
@@ -16,7 +16,8 @@ import {MainnetAddresses} from "./fixtures/MainnetAddresses.sol";
 import {IOraclePassThrough} from "../../oracle/IOraclePassThrough.sol";
 import {PegStabilityModule} from "../../peg/PegStabilityModule.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "./../unit/utils/Fixtures.sol";
 
 /// Differential Test that compares current production PSM to the new PSM
 /// to ensure parity in behavior
@@ -24,8 +25,6 @@ import {getCoreV2, getAddresses, VoltTestAddresses} from "./../unit/utils/Fixtur
 /// increase values for fuzzer for more realistic tests
 contract IntegrationTestDaiCleanPriceBoundPSM is DSTest {
     using SafeCast for *;
-
-    VoltTestAddresses public addresses = getAddresses();
 
     /// reference PSM to test against
     PegStabilityModule private immutable priceBoundPsm =

--- a/contracts/test/integration/IntegrationTestMorphoCompoundPCVDeposit.t.sol
+++ b/contracts/test/integration/IntegrationTestMorphoCompoundPCVDeposit.t.sol
@@ -16,13 +16,13 @@ import {MainnetAddresses} from "./fixtures/MainnetAddresses.sol";
 import {PegStabilityModule} from "../../peg/PegStabilityModule.sol";
 import {ERC20CompoundPCVDeposit} from "../../pcv/compound/ERC20CompoundPCVDeposit.sol";
 import {MorphoCompoundPCVDeposit} from "../../pcv/morpho/MorphoCompoundPCVDeposit.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "./../unit/utils/Fixtures.sol";
 
 contract IntegrationTestMorphoCompoundPCVDeposit is DSTest {
     using SafeCast for *;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     CoreV2 private core;
     SystemEntry public entry;

--- a/contracts/test/integration/IntegrationTestPriceBoundPSM.t.sol
+++ b/contracts/test/integration/IntegrationTestPriceBoundPSM.t.sol
@@ -19,12 +19,11 @@ import {IOraclePassThrough} from "../../oracle/IOraclePassThrough.sol";
 import {PegStabilityModule} from "../../peg/PegStabilityModule.sol";
 import {ERC20CompoundPCVDeposit} from "../../pcv/compound/ERC20CompoundPCVDeposit.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "../unit/utils/Fixtures.sol";
 
 contract IntegrationTestPriceBoundPSMTest is DSTest {
     using SafeCast for *;
-
-    VoltTestAddresses public addresses = getAddresses();
 
     IVolt private volt;
     ICoreV2 private core;

--- a/contracts/test/integration/IntegrationTestPriceBoundPSMUSDC.t.sol
+++ b/contracts/test/integration/IntegrationTestPriceBoundPSMUSDC.t.sol
@@ -18,12 +18,11 @@ import {IOraclePassThrough} from "../../oracle/IOraclePassThrough.sol";
 import {PegStabilityModule} from "../../peg/PegStabilityModule.sol";
 import {ERC20CompoundPCVDeposit} from "../../pcv/compound/ERC20CompoundPCVDeposit.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "./../unit/utils/Fixtures.sol";
 
 contract IntegrationTestPriceBoundPSMUSDCTest is DSTest {
     using SafeCast for *;
-
-    VoltTestAddresses public addresses = getAddresses();
 
     IVolt private volt;
     ICoreV2 private core;

--- a/contracts/test/invariant/InvariantTestMorphoPCVDeposit.t.sol
+++ b/contracts/test/invariant/InvariantTestMorphoPCVDeposit.t.sol
@@ -14,7 +14,8 @@ import {SystemEntry} from "../../entry/SystemEntry.sol";
 import {MockPCVOracle} from "../../mock/MockPCVOracle.sol";
 import {DSInvariantTest} from "../unit/utils/DSInvariantTest.sol";
 import {MorphoCompoundPCVDeposit} from "../../pcv/morpho/MorphoCompoundPCVDeposit.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "../unit/utils/Fixtures.sol";
 
 /// note all variables have to be public and not immutable otherwise foundry
 /// will not run invariant tests
@@ -33,7 +34,6 @@ contract InvariantTestMorphoCompoundPCVDeposit is DSTest, DSInvariantTest {
     MorphoCompoundPCVDeposit public morphoDeposit;
 
     Vm private vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     function setUp() public {
         core = getCoreV2();
@@ -107,7 +107,6 @@ contract InvariantTestMorphoCompoundPCVDeposit is DSTest, DSInvariantTest {
 }
 
 contract MorphoPCVDepositTest is DSTest {
-    VoltTestAddresses public addresses = getAddresses();
     Vm private vm = Vm(HEVM_ADDRESS);
 
     uint256 public totalDeposited;

--- a/contracts/test/invariant/InvariantTestPegStabilityModule.t.sol
+++ b/contracts/test/invariant/InvariantTestPegStabilityModule.t.sol
@@ -15,7 +15,8 @@ import {DSInvariantTest} from "../unit/utils/DSInvariantTest.sol";
 import {VoltSystemOracle} from "../../oracle/VoltSystemOracle.sol";
 import {PegStabilityModule} from "../../peg/PegStabilityModule.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../unit/utils/TestAddresses.sol";
+import {getCoreV2} from "../unit/utils/Fixtures.sol";
 
 /// note all variables have to be public and not immutable otherwise foundry
 /// will not run invariant tests
@@ -35,7 +36,6 @@ contract InvariantTestPegStabilityModule is DSTest, DSInvariantTest {
     PegStabilityModuleTest public morphoTest;
 
     Vm private vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     /// ---------- PSM PARAMS ----------
 
@@ -130,7 +130,6 @@ contract PegStabilityModuleTest is DSTest {
     PCVGuardian public pcvGuardian;
 
     Vm private vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     constructor(
         PegStabilityModule _psm,

--- a/contracts/test/unit/Volt.t.sol
+++ b/contracts/test/unit/Volt.t.sol
@@ -9,7 +9,8 @@ import {ICore} from "../../core/ICore.sol";
 import {Core} from "../../core/Core.sol";
 import {Vm} from "./utils/Vm.sol";
 import {DSTest} from "./utils/DSTest.sol";
-import {getCore, getAddresses, VoltTestAddresses} from "./utils/Fixtures.sol";
+import {getCore} from "./utils/Fixtures.sol";
+import {TestAddresses as addresses} from "./utils/TestAddresses.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 
 contract UnitTestVolt is DSTest {
@@ -17,7 +18,6 @@ contract UnitTestVolt is DSTest {
     ICore private core;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     function setUp() public {
         core = getCore();

--- a/contracts/test/unit/core/Core.t.sol
+++ b/contracts/test/unit/core/Core.t.sol
@@ -11,14 +11,14 @@ import {Core} from "../../../core/Core.sol";
 import {IVolt} from "../../../volt/Volt.sol";
 import {ICore} from "../../../core/ICore.sol";
 import {DSTest} from "./../utils/DSTest.sol";
-import {getCore, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCore} from "./../utils/Fixtures.sol";
 
 contract UnitTestCore is DSTest {
     IVolt private volt;
     Core private core;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     function setUp() public {
         core = getCore();

--- a/contracts/test/unit/core/CoreV2.t.sol
+++ b/contracts/test/unit/core/CoreV2.t.sol
@@ -13,13 +13,13 @@ import {ICore} from "../../../core/ICore.sol";
 import {IGRLM} from "../../../minter/IGRLM.sol";
 import {DSTest} from "./../utils/DSTest.sol";
 import {CoreV2} from "../../../core/CoreV2.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2} from "./../utils/Fixtures.sol";
 
 contract UnitTestCoreV2 is DSTest {
     CoreV2 private core;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
     address volt;
     address vcon;
 

--- a/contracts/test/unit/core/GlobalReentrancyLock.t.sol
+++ b/contracts/test/unit/core/GlobalReentrancyLock.t.sol
@@ -15,13 +15,13 @@ import {VoltRoles} from "../../../core/VoltRoles.sol";
 import {MockERC20} from "./../../../mock/MockERC20.sol";
 import {MockReentrancyLock} from "./../../../mock/MockReentrancyLock.sol";
 import {MockReentrancyLockFailure} from "./../../../mock/MockReentrancyLockFailure.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2} from "./../utils/Fixtures.sol";
 
 contract UnitTestGlobalReentrancyLock is DSTest {
     CoreV2 private core;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
     MockERC20 volt;
     MockReentrancyLock private lock;
     Vcon vcon;

--- a/contracts/test/unit/core/PermissionsV2.t.sol
+++ b/contracts/test/unit/core/PermissionsV2.t.sol
@@ -9,13 +9,13 @@ import {Vm} from "./../utils/Vm.sol";
 import {DSTest} from "./../utils/DSTest.sol";
 import {CoreV2} from "../../../core/CoreV2.sol";
 import {VoltRoles} from "../../../core/VoltRoles.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2} from "./../utils/Fixtures.sol";
 
 contract UnitTestPermissionsV2 is DSTest {
     CoreV2 private core;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     function setUp() public {
         core = getCoreV2();

--- a/contracts/test/unit/minter/GlobalRateLimitedMinter.t.sol
+++ b/contracts/test/unit/minter/GlobalRateLimitedMinter.t.sol
@@ -9,7 +9,8 @@ import {Test} from "../../../../forge-std/src/Test.sol";
 import {ICoreV2} from "../../../core/ICoreV2.sol";
 import {MockMinter} from "../../../mock/MockMinter.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, getVoltAddresses, VoltAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2, getVoltAddresses, VoltAddresses} from "./../utils/Fixtures.sol";
 
 /// deployment steps
 /// 1. core v2
@@ -22,7 +23,6 @@ import {getCoreV2, getAddresses, getVoltAddresses, VoltAddresses, VoltTestAddres
 contract GlobalRateLimitedMinterUnitTest is Test {
     using SafeCast for *;
 
-    VoltTestAddresses public addresses = getAddresses();
     VoltAddresses public guardianAddresses = getVoltAddresses();
 
     GlobalRateLimitedMinter public grlm;

--- a/contracts/test/unit/pcv/ERC20HoldingPCVDeposit.t.sol
+++ b/contracts/test/unit/pcv/ERC20HoldingPCVDeposit.t.sol
@@ -8,7 +8,8 @@ import {VoltRoles} from "../../../core/VoltRoles.sol";
 import {IPCVDeposit} from "../../../pcv/IPCVDeposit.sol";
 import {MockERC20, IERC20} from "../../../mock/MockERC20.sol";
 import {ERC20HoldingPCVDeposit} from "../../../mock/ERC20HoldingPCVDeposit.sol";
-import {getCore, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCore} from "./../utils/Fixtures.sol";
 
 contract UnitTestERC20HoldingsPCVDeposit is DSTest {
     event Deposit(address indexed _from, uint256 _amount);
@@ -18,8 +19,6 @@ contract UnitTestERC20HoldingsPCVDeposit is DSTest {
     ERC20HoldingPCVDeposit private erc20HoldingDeposit;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-
-    VoltTestAddresses public addresses = getAddresses();
 
     /// @notice token to deposit
     MockERC20 private token;

--- a/contracts/test/unit/pcv/PCVGuardian.t.sol
+++ b/contracts/test/unit/pcv/PCVGuardian.t.sol
@@ -9,7 +9,8 @@ import {MockERC20} from "../../../mock/MockERC20.sol";
 import {PCVGuardian} from "../../../pcv/PCVGuardian.sol";
 import {SystemEntry} from "../../../entry/SystemEntry.sol";
 import {MockPCVDepositV2} from "../../../mock/MockPCVDepositV2.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2} from "./../utils/Fixtures.sol";
 
 contract UnitTestPCVGuardian is DSTest {
     event SafeAddressUpdated(
@@ -25,7 +26,6 @@ contract UnitTestPCVGuardian is DSTest {
     MockPCVDepositV2 public pcvDeposit;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     address[] public whitelistAddresses;
     address public guard = address(0x123456789);

--- a/contracts/test/unit/pcv/morpho/MorphoCompoundPCVDeposit.t.sol
+++ b/contracts/test/unit/pcv/morpho/MorphoCompoundPCVDeposit.t.sol
@@ -16,7 +16,8 @@ import {MockPCVOracle} from "../../../../mock/MockPCVOracle.sol";
 import {MockERC20, IERC20} from "../../../../mock/MockERC20.sol";
 import {MorphoCompoundPCVDeposit} from "../../../../pcv/morpho/MorphoCompoundPCVDeposit.sol";
 import {MockMorphoMaliciousReentrancy} from "../../../../mock/MockMorphoMaliciousReentrancy.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../../utils/TestAddresses.sol";
+import {getCoreV2} from "./../../utils/Fixtures.sol";
 
 contract UnitTestMorphoCompoundPCVDeposit is DSTest {
     using SafeCast for *;
@@ -39,8 +40,6 @@ contract UnitTestMorphoCompoundPCVDeposit is DSTest {
     MockMorphoMaliciousReentrancy private maliciousMorpho;
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-
-    VoltTestAddresses public addresses = getAddresses();
 
     /// @notice token to deposit
     MockERC20 private token;

--- a/contracts/test/unit/pcv/utils/ERC20Allocator.t.sol
+++ b/contracts/test/unit/pcv/utils/ERC20Allocator.t.sol
@@ -10,7 +10,8 @@ import {VoltRoles} from "../../../../core/VoltRoles.sol";
 import {PCVDeposit} from "../../../../pcv/PCVDeposit.sol";
 import {ERC20Allocator} from "../../../../pcv/utils/ERC20Allocator.sol";
 import {ERC20HoldingPCVDeposit} from "../../../../mock/ERC20HoldingPCVDeposit.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../../utils/TestAddresses.sol";
+import {getCoreV2} from "./../../utils/Fixtures.sol";
 
 contract UnitTestERC20Allocator is DSTest {
     /// @notice emitted when an existing deposit is updated
@@ -30,7 +31,6 @@ contract UnitTestERC20Allocator is DSTest {
 
     ICoreV2 private core;
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     /// @notice reference to the PCVDeposit to pull from
     ERC20HoldingPCVDeposit private pcvDeposit;

--- a/contracts/test/unit/pcv/utils/ERC20AllocatorConnector.t.sol
+++ b/contracts/test/unit/pcv/utils/ERC20AllocatorConnector.t.sol
@@ -11,7 +11,8 @@ import {PCVDeposit} from "../../../../pcv/PCVDeposit.sol";
 import {VoltRoles} from "../../../../core/VoltRoles.sol";
 import {ERC20Allocator} from "../../../../pcv/utils/ERC20Allocator.sol";
 import {ERC20HoldingPCVDeposit} from "../../../../mock/ERC20HoldingPCVDeposit.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../../utils/TestAddresses.sol";
+import {getCoreV2} from "./../../utils/Fixtures.sol";
 
 contract UnitTestERC20AllocatorConnector is DSTest {
     /// @notice emitted when an existing deposit is updated
@@ -40,7 +41,6 @@ contract UnitTestERC20AllocatorConnector is DSTest {
 
     ICoreV2 private core;
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     /// @notice reference to the PCVDeposit to pull from
     ERC20HoldingPCVDeposit private pcvDeposit;

--- a/contracts/test/unit/peg/UnitTestNonCustodialPSM.t.sol
+++ b/contracts/test/unit/peg/UnitTestNonCustodialPSM.t.sol
@@ -20,7 +20,8 @@ import {CompoundPCVRouter} from "../../../pcv/compound/CompoundPCVRouter.sol";
 import {PegStabilityModule} from "../../../peg/PegStabilityModule.sol";
 import {IScalingPriceOracle} from "../../../oracle/IScalingPriceOracle.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, getVoltAddresses, VoltAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2, getVoltAddresses, VoltAddresses} from "./../utils/Fixtures.sol";
 
 /// deployment steps
 /// 1. core v2
@@ -58,7 +59,6 @@ contract NonCustodialPSMUnitTest is Test {
 
     event PCVDepositUpdate(IPCVDeposit oldTarget, IPCVDeposit newPCVDeposit);
 
-    VoltTestAddresses public addresses = getAddresses();
     VoltAddresses public guardianAddresses = getVoltAddresses();
 
     ICoreV2 private core;

--- a/contracts/test/unit/peg/UnitTestPegStabilityModule.t.sol
+++ b/contracts/test/unit/peg/UnitTestPegStabilityModule.t.sol
@@ -18,12 +18,12 @@ import {NonCustodialPSM} from "../../../peg/NonCustodialPSM.sol";
 import {VoltSystemOracle} from "../../../oracle/VoltSystemOracle.sol";
 import {PegStabilityModule} from "../../../peg/PegStabilityModule.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, getLocalOracleSystem, VoltTestAddresses} from "./../../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2, getLocalOracleSystem} from "./../../unit/utils/Fixtures.sol";
 
 /// PSM Unit Test that tests new PSM to ensure proper behavior
 contract UnitTestPegStabilityModule is Test {
     using SafeCast for *;
-    VoltTestAddresses public addresses = getAddresses();
 
     /// @notice PSM to test against
     PegStabilityModule private psm;

--- a/contracts/test/unit/refs/CoreRefV2.t.sol
+++ b/contracts/test/unit/refs/CoreRefV2.t.sol
@@ -7,13 +7,13 @@ import {ICoreV2} from "../../../core/ICoreV2.sol";
 import {VoltRoles} from "../../../core/VoltRoles.sol";
 import {MockERC20} from "../../../mock/MockERC20.sol";
 import {MockCoreRefV2} from "../../../mock/MockCoreRefV2.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2} from "./../utils/Fixtures.sol";
 
 contract UnitTestCoreRefV2 is DSTest {
     ICoreV2 private core;
     MockCoreRefV2 private coreRef;
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses public addresses = getAddresses();
 
     event CoreUpdate(address indexed oldCore, address indexed newCore);
 

--- a/contracts/test/unit/refs/OracleRef.t.sol
+++ b/contracts/test/unit/refs/OracleRef.t.sol
@@ -6,14 +6,14 @@ import {MockOracle} from "../../../mock/MockOracle.sol";
 import {MockOracleRef} from "../../../mock/MockOracleRef.sol";
 import {Test, console2} from "../../../../forge-std/src/Test.sol";
 import {VoltSystemOracle} from "../../../oracle/VoltSystemOracle.sol";
-import {getCoreV2, getAddresses, getVoltSystemOracle, VoltTestAddresses} from "./../../unit/utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2, getVoltSystemOracle} from "./../../unit/utils/Fixtures.sol";
 
 contract UnitTestOracleRef is Test {
     uint128 voltStartingPrice = 1.01e18;
 
     ICoreV2 private core;
     MockOracleRef private oracleRef;
-    VoltTestAddresses public addresses = getAddresses();
     VoltSystemOracle public oracle;
     bool public constant doInvert = false;
     int256 public constant decimalsNormalizer = 0;

--- a/contracts/test/unit/system/System.t.sol
+++ b/contracts/test/unit/system/System.t.sol
@@ -20,7 +20,8 @@ import {CompoundPCVRouter} from "../../../pcv/compound/CompoundPCVRouter.sol";
 import {PegStabilityModule} from "../../../peg/PegStabilityModule.sol";
 import {IScalingPriceOracle} from "../../../oracle/IScalingPriceOracle.sol";
 import {IGRLM, GlobalRateLimitedMinter} from "../../../minter/GlobalRateLimitedMinter.sol";
-import {getCoreV2, getAddresses, getVoltAddresses, VoltAddresses, VoltTestAddresses} from "./../utils/Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2, getVoltAddresses, VoltAddresses} from "./../utils/Fixtures.sol";
 
 import "hardhat/console.sol";
 
@@ -61,8 +62,6 @@ interface IERC20Mintable is IERC20 {
 
 contract SystemUnitTest is Test {
     using SafeCast for *;
-
-    VoltTestAddresses public addresses = getAddresses();
     VoltAddresses public guardianAddresses = getVoltAddresses();
 
     ICoreV2 private core;

--- a/contracts/test/unit/utils/Fixtures.sol
+++ b/contracts/test/unit/utils/Fixtures.sol
@@ -7,6 +7,7 @@ import {MockERC20} from "./../../../mock/MockERC20.sol";
 import {VoltSystemOracle} from "../../../oracle/VoltSystemOracle.sol";
 import {IOraclePassThrough} from "../../../oracle/IOraclePassThrough.sol";
 import {IScalingPriceOracle} from "../../../oracle/IScalingPriceOracle.sol";
+import {TestAddresses} from "./TestAddresses.sol";
 import {Core, Vcon, Volt, IERC20, IVolt} from "../../../core/Core.sol";
 
 struct VoltTestAddresses {
@@ -29,27 +30,6 @@ struct VoltAddresses {
     address pcvGuardAddress1; // address(0xf8D0387538E8e03F3B4394dA89f221D7565a28Ee),
     address pcvGuardAddress2; // address(0xd90E9181B20D8D1B5034d9f5737804Da182039F6),
     address executorAddress; // address(0xcBB83206698E8788F85EFbEeeCAd17e53366EBDf) // msig is executor
-}
-
-/// @dev Get a list of addresses
-function getAddresses() pure returns (VoltTestAddresses memory) {
-    VoltTestAddresses memory addresses = VoltTestAddresses({
-        userAddress: address(0x1),
-        secondUserAddress: address(0x2),
-        beneficiaryAddress1: address(0x3),
-        beneficiaryAddress2: address(0x4),
-        governorAddress: address(0x5),
-        genesisGroup: address(0x6),
-        keeperAddress: address(0x7),
-        pcvControllerAddress: address(0x8),
-        minterAddress: address(0x9),
-        burnerAddress: address(0x10),
-        guardianAddress: address(0x11),
-        voltGovernorAddress: address(0x12),
-        voltDeployerAddress: address(0x13)
-    });
-
-    return addresses;
 }
 
 function getVoltAddresses() pure returns (VoltAddresses memory addresses) {
@@ -91,19 +71,21 @@ function getCore() returns (Core) {
         bytes20(uint160(uint256(keccak256("hevm cheat code"))))
     );
     Vm vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses memory addresses = getAddresses();
 
     // Deploy Core from Governor address
-    vm.startPrank(addresses.governorAddress);
+    vm.startPrank(TestAddresses.governorAddress);
     Core core = new Core();
     core.init();
-    Vcon vcon = new Vcon(addresses.governorAddress, addresses.governorAddress);
+    Vcon vcon = new Vcon(
+        TestAddresses.governorAddress,
+        TestAddresses.governorAddress
+    );
 
     core.setVcon(IERC20(address(vcon)));
-    core.grantMinter(addresses.minterAddress);
-    core.grantBurner(addresses.burnerAddress);
-    core.grantPCVController(addresses.pcvControllerAddress);
-    core.grantGuardian(addresses.guardianAddress);
+    core.grantMinter(TestAddresses.minterAddress);
+    core.grantBurner(TestAddresses.burnerAddress);
+    core.grantPCVController(TestAddresses.pcvControllerAddress);
+    core.grantGuardian(TestAddresses.guardianAddress);
 
     vm.stopPrank();
     return core;
@@ -115,18 +97,20 @@ function getCoreV2() returns (CoreV2) {
         bytes20(uint160(uint256(keccak256("hevm cheat code"))))
     );
     Vm vm = Vm(HEVM_ADDRESS);
-    VoltTestAddresses memory addresses = getAddresses();
 
     MockERC20 volt = new MockERC20();
     // Deploy Core from Governor address
-    vm.startPrank(addresses.governorAddress);
+    vm.startPrank(TestAddresses.governorAddress);
     CoreV2 core = new CoreV2(address(volt));
-    Vcon vcon = new Vcon(addresses.governorAddress, addresses.governorAddress);
+    Vcon vcon = new Vcon(
+        TestAddresses.governorAddress,
+        TestAddresses.governorAddress
+    );
 
     core.setVcon(IERC20(address(vcon)));
-    core.grantMinter(addresses.minterAddress);
-    core.grantPCVController(addresses.pcvControllerAddress);
-    core.grantGuardian(addresses.guardianAddress);
+    core.grantMinter(TestAddresses.minterAddress);
+    core.grantPCVController(TestAddresses.pcvControllerAddress);
+    core.grantGuardian(TestAddresses.guardianAddress);
 
     vm.stopPrank();
     return core;
@@ -156,17 +140,13 @@ function getOraclePassThrough(
 function getLocalOracleSystem()
     returns (VoltSystemOracle oracle, IOraclePassThrough opt)
 {
-    VoltTestAddresses memory addresses = getAddresses();
-
     oracle = getVoltSystemOracle(100, block.timestamp, 1e18);
-    opt = getOraclePassThrough(oracle, addresses.governorAddress);
+    opt = getOraclePassThrough(oracle, TestAddresses.governorAddress);
 }
 
 function getLocalOracleSystem(
     uint256 startPrice
 ) returns (VoltSystemOracle oracle, IOraclePassThrough opt) {
-    VoltTestAddresses memory addresses = getAddresses();
-
     oracle = getVoltSystemOracle(100, block.timestamp, startPrice);
-    opt = getOraclePassThrough(oracle, addresses.governorAddress);
+    opt = getOraclePassThrough(oracle, TestAddresses.governorAddress);
 }

--- a/contracts/test/unit/utils/RateLimitedV2.t.sol
+++ b/contracts/test/unit/utils/RateLimitedV2.t.sol
@@ -12,7 +12,8 @@ import {VoltRoles} from "../../../core/VoltRoles.sol";
 import {ERC20Allocator} from "../../../pcv/utils/ERC20Allocator.sol";
 import {MockRateLimitedV2} from "../../../mock/MockRateLimitedV2.sol";
 import {ERC20HoldingPCVDeposit} from "../../../mock/ERC20HoldingPCVDeposit.sol";
-import {getCoreV2, getAddresses, VoltTestAddresses} from "./Fixtures.sol";
+import {TestAddresses as addresses} from "../utils/TestAddresses.sol";
+import {getCoreV2} from "./Fixtures.sol";
 
 contract UnitTestRateLimitedV2 is DSTest {
     using SafeCast for *;
@@ -34,9 +35,6 @@ contract UnitTestRateLimitedV2 is DSTest {
 
     /// @notice foundry vm
     Vm public constant vm = Vm(HEVM_ADDRESS);
-
-    /// @notice test addresses
-    VoltTestAddresses public addresses = getAddresses();
 
     /// @notice rate limited v2 contract
     MockRateLimitedV2 rlm;

--- a/contracts/test/unit/utils/TestAddresses.sol
+++ b/contracts/test/unit/utils/TestAddresses.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier = GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+library TestAddresses {
+    address public constant userAddress = address(0x1);
+    address public constant secondUserAddress = address(0x2);
+    address public constant beneficiaryAddress1 = address(0x3);
+    address public constant beneficiaryAddress2 = address(0x4);
+    address public constant governorAddress = address(0x5);
+    address public constant genesisGroup = address(0x6);
+    address public constant keeperAddress = address(0x7);
+    address public constant pcvControllerAddress = address(0x8);
+    address public constant minterAddress = address(0x9);
+    address public constant burnerAddress = address(0x10);
+    address public constant guardianAddress = address(0x11);
+    address public constant voltGovernorAddress = address(0x12);
+    address public constant voltDeployerAddress = address(0x13);
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,9 +1,8 @@
 [profile.default]
 optimizer = true
 optimizer_runs = 200
-lib-paths = "node_modules"
 contracts = "contracts"
 fuzz_max_global_rejects = 100000
 fuzz_max_local_rejects = 100000
 fuzz_runs = 500
-libs = ["node_modules", "lib"]
+libs = ['node_modules', 'lib', 'contracts/test', 'contracts/mock', 'forge-std/lib/ds-test/src', 'forge-std/src']

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,4 +5,6 @@ contracts = "contracts"
 fuzz_max_global_rejects = 100000
 fuzz_max_local_rejects = 100000
 fuzz_runs = 500
+# 'contracts/test', 'contracts/mock', 'forge-std/lib/ds-test/src', 'forge-std/src' are added here
+# to not appear in the code coverage result when using forge coverage
 libs = ['node_modules', 'lib', 'contracts/test', 'contracts/mock', 'forge-std/lib/ds-test/src', 'forge-std/src']

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:proposal:arbitrum": "forge test --fork-url https://arb-mainnet.g.alchemy.com/v2/$ARBITRUM_ALCHEMY_API_KEY --match-test testProposalArbitrum -vvv",
     "test:integration": "forge test --fork-url https://eth-mainnet.alchemyapi.io/v2/$MAINNET_ALCHEMY_API_KEY --match-contract IntegrationTest -vvv",
     "test:integration:arbitrum": "forge test --fork-url https://arb-mainnet.g.alchemy.com/v2/$ARBITRUM_ALCHEMY_API_KEY --match-contract ArbitrumTest -vvv",
+    "coverage": "forge coverage --match-contract UnitTest --report summary --report lcov",
     "lint": "npm run lint:ts && npm run lint:sol",
     "lint:ts": "npx eslint --config ./.eslintrc --ignore-path ./.eslintignore --ext .ts,.tsx .",
     "lint-all": "npx eslint --config ./.eslintrc --ignore-path ./.eslintignore --ext .js,.jsx,.ts,.tsx .",


### PR DESCRIPTION
This PR fixes the following error that was occuring when trying to run `forge coverage` :
```
Error: 
Compiler run failed
CompilerError: Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.
```

The problem was the getAddresses() function in the Fixtures.sol file which was apparently returning too much variables.

The reason the error was visible when running `forge coverage` and not when running `forge build` or `forge test` is because when running coverage, forge disable optimizations. To be able to see the error when building using `forge build`, you must disable optimization in foundry.toml:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/9356022/203834023-e27220b6-e14b-4532-893e-1d980db9e677.png">

Sadly, if you encounter the error `CompilerError: Stack too deep when compiling inline assembly: Variable value0 is 1 slot(s) too deep inside the stack.`, it does not give you the problematic(s) contract(s). The only way I was able to see what were the problematic contracts was to run `forge build --contracts={path/to/Contract.sol}` for each contracts in the repo and to see where the build was failing.

Best way to do that was to run the following command: 
`find ./contracts/**/*.sol -exec echo {} \; -exec forge build --contracts={} \;`

Which will find every .sol files and run the forge build command on it and will display the contract name before compiling:
<img width="273" alt="image" src="https://user-images.githubusercontent.com/9356022/203837126-217c3f2d-0b52-4110-ac25-aaa7cb21bfc8.png">


That way you can see what contract is problematic for the non-optimized compilation.

Now that the coverage works, you can display it using the npm script `npm run coverage` which is in fact the following command: 
`forge coverage --match-contract UnitTest --report summary --report lcov`

It will display the coverage result in your terminal and also generate a lcov.info at the project root directory

**Terminal display:**
<img width="854" alt="image" src="https://user-images.githubusercontent.com/9356022/203835811-a83f76e1-62d2-493d-9bf5-b022754cb00f.png">

**Using the lcov.info file**

The lcov report can be used, for example, with the [Coverage Gutters extension](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) (in VS code):

For example, we can see that the 'PCVDeposit.sol' contract only has 50% coverage, this is what you'll see when opening the contract with the Coverage Gutters extension installed and configured:

<img width="772" alt="image" src="https://user-images.githubusercontent.com/9356022/203836383-8060a364-9d3c-4c16-92b0-b5a7ac544104.png">

Which makes it very easy to check what unit tests should be added, here it shows that the two functions `withdrawETH` and `resistantBalanceAndVolt` seems to not be tested

The lcov report can also be used during the CI, here's an example (in another repo) where I used the lcov report to generate a message when a PR was created:
<img width="694" alt="image" src="https://user-images.githubusercontent.com/9356022/203836887-5b2e3365-190a-440c-963a-5c4420b6ceae.png">
