### PR TITLE
Add updateChangeRateBasisPoints function to VoltSystemOracle

### DIFF
--- a/contracts/oracle/IVoltSystemOracle.sol
+++ b/contracts/oracle/IVoltSystemOracle.sol
@@ -32,9 +32,22 @@ interface IVoltSystemOracle {
     /// Sets accumulator to the current accrued interest, and then resets the timer.
     function compoundInterest() external;
 
+    /// @notice update the change rate in basis points
+    /// callable only by the governor
+    /// @param newMonthlyChangeRateBasisPoints basis points to interpolate price
+    function updateChangeRateBasisPoints(
+        uint256 newMonthlyChangeRateBasisPoints
+    ) external;
+
     // ----------- Event -----------
 
     /// @notice event emitted when the Volt system oracle compounds
     /// emits the end time of the period that completed and the new oracle price
     event InterestCompounded(uint256 periodStart, uint256 newOraclePrice);
+
+    /// @notice emitted when Volt system oracle change rate updates
+    event ChangeRateUpdated(
+        uint256 oldChangeRateBasisPoints,
+        uint256 newChangeRateBasisPoints
+    );
 }

--- a/contracts/oracle/VoltSystemOracle.sol
+++ b/contracts/oracle/VoltSystemOracle.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
-import {Decimal} from "../external/Decimal.sol";
 import {Constants} from "./../Constants.sol";
 import {CoreRefV2} from "../refs/CoreRefV2.sol";
+import {IOracleV2} from "../oracle/IOracleV2.sol";
 import {IVoltSystemOracle} from "./IVoltSystemOracle.sol";
 
 /// @notice contract that receives a fixed interest rate upon construction,
@@ -13,23 +14,25 @@ import {IVoltSystemOracle} from "./IVoltSystemOracle.sol";
 /// after the oracle start time.
 /// Interest compounds once per month.
 /// @author Elliot Friedman
-contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2 {
-    using Decimal for Decimal.D256;
+contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2, IOracleV2 {
+    using SafeCast for *;
 
-    /// ---------- Mutable Variables ----------
+    /// ----------------------------------------
+    /// ---------  Mutable Variables  ----------
+    /// --------- Single Storage Slot ----------
+    /// ----------------------------------------
 
     /// @notice acts as an accumulator for interest earned in previous periods
     /// returns the oracle price from the end of the last period
-    uint256 public oraclePrice;
+    uint200 private _oraclePrice;
 
     /// @notice start time at which point interest will start accruing, and the
     /// current ScalingPriceOracle price will be snapshotted and saved
-    uint256 public periodStartTime;
-
-    /// ---------- Mutable Variable ----------
+    uint40 private _periodStartTime;
 
     /// @notice current amount that oracle price is inflating by monthly in basis points
-    uint256 public monthlyChangeRateBasisPoints;
+    /// cannot be greater than 65,535 basis points per month
+    uint16 private _monthlyChangeRateBasisPoints;
 
     /// ---------- Immutable Variable ----------
 
@@ -37,51 +40,71 @@ contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2 {
     /// one month was chosen because this is a temporary oracle
     uint256 public constant TIMEFRAME = 30.42 days;
 
-    /// @param _monthlyChangeRateBasisPoints monthly change rate in the Volt price
-    /// @param _periodStartTime start time at which oracle starts interpolating prices
-    /// @param _oraclePrice starting oracle price
+    /// @param _core reference
+    /// @param startingMonthlyChangeRateBasisPoints monthly change rate in the Volt price
+    /// @param startingPeriodStartTime start time at which oracle starts interpolating prices
+    /// @param startingoraclePrice starting oracle price
     constructor(
         address _core,
-        uint256 _monthlyChangeRateBasisPoints,
-        uint256 _periodStartTime,
-        uint256 _oraclePrice
+        uint16 startingMonthlyChangeRateBasisPoints,
+        uint40 startingPeriodStartTime,
+        uint200 startingoraclePrice
     ) CoreRefV2(_core) {
-        monthlyChangeRateBasisPoints = _monthlyChangeRateBasisPoints;
-        periodStartTime = _periodStartTime;
-        oraclePrice = _oraclePrice;
+        _monthlyChangeRateBasisPoints = startingMonthlyChangeRateBasisPoints;
+        _periodStartTime = startingPeriodStartTime;
+        _oraclePrice = startingoraclePrice;
     }
 
-    // ----------- Getter -----------
+    // ----------- Getters -----------
 
     /// @notice get the current scaled oracle price
     /// applies the change rate smoothly over a 30.42 day period
     /// scaled by 18 decimals
     // prettier-ignore
     function getCurrentOraclePrice() public view override returns (uint256) {
-        uint256 cachedStartTime = periodStartTime; /// save a single warm SLOAD if condition is false
+        uint256 cachedStartTime = _periodStartTime; /// save a single warm SLOAD if condition is false
         if (cachedStartTime >= block.timestamp) { /// only accrue interest after start time
-            return oraclePrice;
+            return _oraclePrice;
         }
 
-        uint256 cachedOraclePrice = oraclePrice; /// save a single warm SLOAD by using the stack
+        uint256 cachedOraclePrice = _oraclePrice; /// save a single warm SLOAD by using the stack
         uint256 timeDelta = Math.min(block.timestamp - cachedStartTime, TIMEFRAME);
-        uint256 pricePercentageChange = cachedOraclePrice * monthlyChangeRateBasisPoints / Constants.BASIS_POINTS_GRANULARITY;
+        uint256 pricePercentageChange = cachedOraclePrice * _monthlyChangeRateBasisPoints / Constants.BASIS_POINTS_GRANULARITY;
         uint256 priceDelta = pricePercentageChange * timeDelta / TIMEFRAME;
 
         return cachedOraclePrice + priceDelta;
     }
 
     /// @notice function to get the current oracle price for the OracleRef contract
-    /// valid is always true, price expressed as a decimal.
-    function read()
+    /// valid is always true, price expressed as a uint256 scaled by 1e18.
+    function read() external view returns (uint256 price, bool valid) {
+        price = getCurrentOraclePrice();
+        valid = true;
+    }
+
+    /// @notice oracle price. starts off at 1e18 and compounds monthly
+    /// acts as an accumulator for interest earned in previous epochs
+    /// returns the oracle price from the end of the last period
+    function oraclePrice() external view override returns (uint256) {
+        return _oraclePrice;
+    }
+
+    /// @notice start time at which point interest will start accruing, and the
+    /// current ScalingPriceOracle price will be snapshotted and saved
+    function periodStartTime() external view override returns (uint256) {
+        return _periodStartTime;
+    }
+
+    /// @notice current amount that oracle price is inflating by monthly in basis points
+    /// does not support negative rates because PCV will not be deposited into negatively
+    /// yielding venues.
+    function monthlyChangeRateBasisPoints()
         external
         view
-        returns (Decimal.D256 memory price, bool valid)
+        override
+        returns (uint256)
     {
-        uint256 currentPrice = getCurrentOraclePrice();
-
-        price = Decimal.from(currentPrice).div(1e18);
-        valid = true;
+        return _monthlyChangeRateBasisPoints;
     }
 
     /// ------------- Public State Changing API -------------
@@ -90,7 +113,7 @@ contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2 {
     /// Sets accumulator to the current accrued interest, and then resets the timer.
     function compoundInterest() external override {
         require(
-            block.timestamp >= periodStartTime + TIMEFRAME,
+            block.timestamp >= _periodStartTime + TIMEFRAME,
             "VoltSystemOracle: not past end time"
         );
 
@@ -105,8 +128,9 @@ contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2 {
     ) external override onlyGovernor {
         _compoundInterest(); /// compound interest before updating change rate
 
-        uint256 oldChangeRateBasisPoints = monthlyChangeRateBasisPoints;
-        monthlyChangeRateBasisPoints = newMonthlyChangeRateBasisPoints;
+        uint256 oldChangeRateBasisPoints = _monthlyChangeRateBasisPoints;
+        _monthlyChangeRateBasisPoints = newMonthlyChangeRateBasisPoints
+            .toUint16();
 
         emit ChangeRateUpdated(
             oldChangeRateBasisPoints,
@@ -117,13 +141,17 @@ contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2 {
     /// @notice helper function to compound interest
     function _compoundInterest() private {
         /// first set Oracle Price to interpolated value
-        oraclePrice = getCurrentOraclePrice();
+        /// this should never remove accuracy as price would need to be greater than
+        /// 1606938044000000000000000000000000000000000000000000000000000
+        /// for this to fail.
+        /// starting price -> 1000000000000000000
+        _oraclePrice = uint200(getCurrentOraclePrice());
 
         /// set periodStartTime to periodStartTime + timeframe,
         /// this is equivalent to init timed, which wipes out all unaccumulated compounded interest
         /// and cleanly sets the start time.
-        periodStartTime = periodStartTime + TIMEFRAME;
+        _periodStartTime = uint40(_periodStartTime + TIMEFRAME);
 
-        emit InterestCompounded(periodStartTime, oraclePrice);
+        emit InterestCompounded(_periodStartTime, _oraclePrice);
     }
 }

--- a/contracts/oracle/VoltSystemOracle.sol
+++ b/contracts/oracle/VoltSystemOracle.sol
@@ -140,18 +140,22 @@ contract VoltSystemOracle is IVoltSystemOracle, CoreRefV2, IOracleV2 {
 
     /// @notice helper function to compound interest
     function _compoundInterest() private {
+        uint200 newOraclePrice = uint200(getCurrentOraclePrice());
+        uint40 newStartTime = uint40(_periodStartTime + TIMEFRAME);
+
+        /// SSTORE
         /// first set Oracle Price to interpolated value
         /// this should never remove accuracy as price would need to be greater than
         /// 1606938044000000000000000000000000000000000000000000000000000
         /// for this to fail.
         /// starting price -> 1000000000000000000
-        _oraclePrice = uint200(getCurrentOraclePrice());
+        _oraclePrice = newOraclePrice;
 
         /// set periodStartTime to periodStartTime + timeframe,
         /// this is equivalent to init timed, which wipes out all unaccumulated compounded interest
         /// and cleanly sets the start time.
-        _periodStartTime = uint40(_periodStartTime + TIMEFRAME);
+        _periodStartTime = newStartTime;
 
-        emit InterestCompounded(_periodStartTime, _oraclePrice);
+        emit InterestCompounded(newStartTime, newOraclePrice);
     }
 }

--- a/contracts/test/invariant/InvariantTestPegStabilityModule.t.sol
+++ b/contracts/test/invariant/InvariantTestPegStabilityModule.t.sol
@@ -58,7 +58,12 @@ contract InvariantTestPegStabilityModule is DSTest, DSInvariantTest {
         pcvOracle = new MockPCVOracle();
         core = getCoreV2();
         token = new MockERC20();
-        oracle = new VoltSystemOracle(0, block.timestamp, voltFloorPrice + 1);
+        oracle = new VoltSystemOracle(
+            address(core),
+            0,
+            block.timestamp,
+            voltFloorPrice + 1
+        );
         psm = new PegStabilityModule(
             address(core),
             address(oracle),

--- a/contracts/test/invariant/InvariantTestPegStabilityModule.t.sol
+++ b/contracts/test/invariant/InvariantTestPegStabilityModule.t.sol
@@ -61,8 +61,8 @@ contract InvariantTestPegStabilityModule is DSTest, DSInvariantTest {
         oracle = new VoltSystemOracle(
             address(core),
             0,
-            block.timestamp,
-            voltFloorPrice + 1
+            uint40(block.timestamp),
+            uint200(voltFloorPrice + 1)
         );
         psm = new PegStabilityModule(
             address(core),

--- a/contracts/test/unit/peg/UnitTestNonCustodialPSM.t.sol
+++ b/contracts/test/unit/peg/UnitTestNonCustodialPSM.t.sol
@@ -117,6 +117,7 @@ contract NonCustodialPSMUnitTest is Test {
         entry = new SystemEntry(address(core));
         dai = IERC20Mintable(address(new MockERC20()));
         oracle = new VoltSystemOracle(
+            coreAddress,
             monthlyChangeRateBasisPoints,
             startTime,
             startPrice

--- a/contracts/test/unit/peg/UnitTestNonCustodialPSM.t.sol
+++ b/contracts/test/unit/peg/UnitTestNonCustodialPSM.t.sol
@@ -104,9 +104,9 @@ contract NonCustodialPSMUnitTest is Test {
 
     /// ---------- ORACLE PARAMS ----------
 
-    uint256 public constant startPrice = 1.05e18;
-    uint256 public constant startTime = 1_000;
-    uint256 public constant monthlyChangeRateBasisPoints = 100;
+    uint200 public constant startPrice = 1.05e18;
+    uint40 public constant startTime = 1_000;
+    uint16 public constant monthlyChangeRateBasisPoints = 100;
 
     function setUp() public {
         vm.warp(startTime); /// warp past 0

--- a/contracts/test/unit/peg/UnitTestPegStabilityModule.t.sol
+++ b/contracts/test/unit/peg/UnitTestPegStabilityModule.t.sol
@@ -60,7 +60,7 @@ contract UnitTestPegStabilityModule is Test {
         underlyingToken = IERC20(address(new MockERC20()));
         core = getCoreV2();
         volt = core.volt();
-        (oracle, ) = getLocalOracleSystem(voltFloorPrice);
+        (oracle, ) = getLocalOracleSystem(address(core), voltFloorPrice);
 
         /// create PSM
         psm = new PegStabilityModule(

--- a/contracts/test/unit/refs/OracleRef.t.sol
+++ b/contracts/test/unit/refs/OracleRef.t.sol
@@ -23,7 +23,7 @@ contract UnitTestOracleRef is Test {
         oracle = getVoltSystemOracle(
             address(core),
             0,
-            block.timestamp,
+            uint40(block.timestamp),
             voltStartingPrice
         );
         oracleRef = new MockOracleRef(

--- a/contracts/test/unit/refs/OracleRef.t.sol
+++ b/contracts/test/unit/refs/OracleRef.t.sol
@@ -20,7 +20,12 @@ contract UnitTestOracleRef is Test {
 
     function setUp() public {
         core = getCoreV2();
-        oracle = getVoltSystemOracle(0, block.timestamp, voltStartingPrice);
+        oracle = getVoltSystemOracle(
+            address(core),
+            0,
+            block.timestamp,
+            voltStartingPrice
+        );
         oracleRef = new MockOracleRef(
             address(core),
             address(oracle),

--- a/contracts/test/unit/system/System.t.sol
+++ b/contracts/test/unit/system/System.t.sol
@@ -114,9 +114,9 @@ contract SystemUnitTest is Test {
 
     /// ---------- ORACLE PARAMS ----------
 
-    uint256 public constant startPrice = 1.05e18;
-    uint256 public constant startTime = 1_000;
-    uint256 public constant monthlyChangeRateBasisPoints = 100;
+    uint200 public constant startPrice = 1.05e18;
+    uint40 public constant startTime = 1_000;
+    uint16 public constant monthlyChangeRateBasisPoints = 100;
 
     function setUp() public {
         vm.warp(startTime); /// warp past 0

--- a/contracts/test/unit/system/System.t.sol
+++ b/contracts/test/unit/system/System.t.sol
@@ -127,6 +127,7 @@ contract SystemUnitTest is Test {
         dai = IERC20Mintable(address(new MockERC20()));
         usdc = IERC20Mintable(address(new MockERC20()));
         oracle = new VoltSystemOracle(
+            address(core),
             monthlyChangeRateBasisPoints,
             startTime,
             startPrice

--- a/contracts/test/unit/utils/Fixtures.sol
+++ b/contracts/test/unit/utils/Fixtures.sol
@@ -118,9 +118,9 @@ function getCoreV2() returns (CoreV2) {
 
 function getVoltSystemOracle(
     address _core,
-    uint256 _monthlyChangeRateBasisPoints,
-    uint256 _periodStartTime,
-    uint256 _oraclePrice
+    uint16 _monthlyChangeRateBasisPoints,
+    uint40 _periodStartTime,
+    uint200 _oraclePrice
 ) returns (VoltSystemOracle) {
     VoltSystemOracle oracle = new VoltSystemOracle(
         _core,
@@ -142,14 +142,19 @@ function getOraclePassThrough(
 function getLocalOracleSystem(
     address core
 ) returns (VoltSystemOracle oracle, IOraclePassThrough opt) {
-    oracle = getVoltSystemOracle(core, 100, block.timestamp, 1e18);
+    oracle = getVoltSystemOracle(core, 100, uint40(block.timestamp), 1e18);
     opt = getOraclePassThrough(oracle, TestAddresses.governorAddress);
 }
 
 function getLocalOracleSystem(
     address core,
-    uint256 startPrice
+    uint200 startPrice
 ) returns (VoltSystemOracle oracle, IOraclePassThrough opt) {
-    oracle = getVoltSystemOracle(core, 100, block.timestamp, startPrice);
+    oracle = getVoltSystemOracle(
+        core,
+        100,
+        uint40(block.timestamp),
+        startPrice
+    );
     opt = getOraclePassThrough(oracle, TestAddresses.governorAddress);
 }

--- a/contracts/test/unit/utils/Fixtures.sol
+++ b/contracts/test/unit/utils/Fixtures.sol
@@ -117,11 +117,13 @@ function getCoreV2() returns (CoreV2) {
 }
 
 function getVoltSystemOracle(
+    address _core,
     uint256 _monthlyChangeRateBasisPoints,
     uint256 _periodStartTime,
     uint256 _oraclePrice
 ) returns (VoltSystemOracle) {
     VoltSystemOracle oracle = new VoltSystemOracle(
+        _core,
         _monthlyChangeRateBasisPoints,
         _periodStartTime,
         _oraclePrice
@@ -137,16 +139,17 @@ function getOraclePassThrough(
     return IOraclePassThrough(address(oracle));
 }
 
-function getLocalOracleSystem()
-    returns (VoltSystemOracle oracle, IOraclePassThrough opt)
-{
-    oracle = getVoltSystemOracle(100, block.timestamp, 1e18);
+function getLocalOracleSystem(
+    address core
+) returns (VoltSystemOracle oracle, IOraclePassThrough opt) {
+    oracle = getVoltSystemOracle(core, 100, block.timestamp, 1e18);
     opt = getOraclePassThrough(oracle, TestAddresses.governorAddress);
 }
 
 function getLocalOracleSystem(
+    address core,
     uint256 startPrice
 ) returns (VoltSystemOracle oracle, IOraclePassThrough opt) {
-    oracle = getVoltSystemOracle(100, block.timestamp, startPrice);
+    oracle = getVoltSystemOracle(core, 100, block.timestamp, startPrice);
     opt = getOraclePassThrough(oracle, TestAddresses.governorAddress);
 }


### PR DESCRIPTION
Allow governor to update change rate so that governance can update the rate without having to redeploy another oracle. This means VoltSystemOracle needs a reference to CoreV2 and only governor can call in and update the rate.