### PR TITLE
Global Reentrancy Modifier Changes

### DIFF
--- a/test/mock/MockCoreRefV2.sol
+++ b/test/mock/MockCoreRefV2.sol
@@ -17,6 +17,17 @@ contract MockCoreRefV2 is CoreRefV2 {
 
     function testSystemState() public onlyVoltRole(VoltRoles.LOCKER) {}
 
+    function testSystemLocksToLevel1() public globalLock(1) {}
+
+    function testSystemLocksToLevel2() public globalLock(2) {}
+
+    /// invalid lock level, doesn't matter because the lock is disabled in test
+    function testSystemLocksToLevel3() public globalLock(3) {}
+
+    function testSystemLockLevel1() public isGlobalReentrancyLocked(1) {}
+
+    function testSystemLockLevel2() public isGlobalReentrancyLocked(2) {}
+
     function testStateGovernorMinter()
         public
         hasAnyOfThreeRoles(

--- a/test/unit/core/GlobalReentrancyLock.t.sol
+++ b/test/unit/core/GlobalReentrancyLock.t.sol
@@ -49,8 +49,8 @@ contract UnitTestGlobalReentrancyLock is Test {
         assertTrue(core.isGovernor(address(core))); /// core contract is governor
         assertTrue(core.isGovernor(addresses.governorAddress)); /// msg.sender of contract is governor
 
-        assertTrue(lock.isUnlocked()); /// core starts out unlocked
-        assertTrue(!lock.isLocked()); /// core starts out not locked
+        assertTrue(lock.isUnlocked()); /// lock starts out unlocked
+        assertTrue(!lock.isLocked()); /// lock starts out not locked
         assertEq(lock.lastSender(), address(0));
         assertEq(lock.lastBlockEntered(), 0);
 
@@ -219,7 +219,7 @@ contract UnitTestGlobalReentrancyLock is Test {
 
             assertTrue(!lock.isLocked());
             assertEq(lock.lockLevel(), 0);
-            assertTrue(lock.isUnlocked()); /// core is fully unlocked
+            assertTrue(lock.isUnlocked()); /// lock is fully unlocked
             assertEq(toPrank, lock.lastSender());
 
             vm.roll(block.number + 1);

--- a/test/unit/refs/CoreRefV2.t.sol
+++ b/test/unit/refs/CoreRefV2.t.sol
@@ -6,10 +6,11 @@ import {Test} from "@forge-std/Test.sol";
 import {ICoreV2} from "@voltprotocol/core/ICoreV2.sol";
 import {VoltRoles} from "@voltprotocol/core/VoltRoles.sol";
 import {MockERC20} from "@test/mock/MockERC20.sol";
+import {getCoreV2} from "@test/unit/utils/Fixtures.sol";
 import {IPCVOracle} from "@voltprotocol/oracle/IPCVOracle.sol";
 import {MockCoreRefV2} from "@test/mock/MockCoreRefV2.sol";
 import {TestAddresses as addresses} from "@test/unit/utils/TestAddresses.sol";
-import {getCoreV2} from "@test/unit/utils/Fixtures.sol";
+import {IGlobalReentrancyLock} from "@voltprotocol/core/IGlobalReentrancyLock.sol";
 
 contract UnitTestCoreRefV2 is Test {
     ICoreV2 private core;
@@ -111,6 +112,36 @@ contract UnitTestCoreRefV2 is Test {
         vm.prank(addresses.governorAddress);
         core.grantLocker(address(this));
         coreRef.testSystemState();
+    }
+
+    function _disableLock() private {
+        vm.prank(addresses.governorAddress);
+        core.setGlobalReentrancyLock(IGlobalReentrancyLock(address(0)));
+    }
+
+    function testLockLevel1LockDisabled() public {
+        _disableLock();
+        coreRef.testSystemLocksToLevel1();
+    }
+
+    function testLockLevel2LockDisabled() public {
+        _disableLock();
+        coreRef.testSystemLocksToLevel2();
+    }
+
+    function testLockLevel3LockDisabled() public {
+        _disableLock();
+        coreRef.testSystemLocksToLevel3();
+    }
+
+    function testSystemLockLevel1LockDisabled() public {
+        _disableLock();
+        coreRef.testSystemLockLevel1();
+    }
+
+    function testSystemLockLevel2LockDisabled() public {
+        _disableLock();
+        coreRef.testSystemLockLevel2();
     }
 
     function testGuardianAsGuardian() public {


### PR DESCRIPTION
CoreRefV2 changes to ignore reentrancy lock and checks when the global reentrancy lock is set to 0.